### PR TITLE
Pairing mode implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,27 @@ The following interfaces are provided:
 ```
 org.freedesktop.tuhi1.Manager
 
-   Property: Devices (ao)
+  Property: Devices (ao)
+      Array of object paths to known (previously paired, but not necessarily
+      connected) devices.
 
-   Array of object paths to known (previously paired, but not necessarily
-   connected) devices.
+  Property: PairableDevices (ass)
+      Array of (bluetooth address, name) of pairable devices that are in
+      proximity.
+
+      This property will only return data when the Manager is in Pairing mode
+
+  Method: StartPairing() -> ()
+      Listen to available devices in pairing mode for an unspecified timeout.
+      When the timeout expires, a PairingComplete signal is sent indicating
+      success or error.
+
+      Returns: nothing
+
+  Method: Pair(s) -> (i)
+      Pairs the given device specified by its bluetooth mac address.
+
+      Returns: 0 on success or a negative errno on failure
 
 org.freedesktop.tuhi1.Device
 

--- a/tuhi.py
+++ b/tuhi.py
@@ -141,6 +141,7 @@ class Tuhi(GObject.Object):
         self.server.connect('start-pairing-requested', self._on_start_pairing_requested)
         self.bluez = BlueZDeviceManager()
         self.bluez.connect('device-added', self._on_bluez_device_added)
+        self.bluez.connect('device-updated', self._on_bluez_device_updated)
 
         self.devices = {}
 
@@ -168,6 +169,15 @@ class Tuhi(GObject.Object):
         tuhi_dbus_device = self.server.create_device(bluez_device)
         d = TuhiDevice(bluez_device, tuhi_dbus_device)
         self.devices[bluez_device.address] = d
+
+    def _on_bluez_device_updated(self, manager, bluez_device):
+        if bluez_device.vendor_id != WACOM_COMPANY_ID:
+            return
+
+        if not Tuhi._is_pairing_device(bluez_device):
+            return
+
+        self.server.add_pairing_device(bluez_device)
 
 
 def main(args):

--- a/tuhi.py
+++ b/tuhi.py
@@ -138,6 +138,7 @@ class Tuhi(GObject.Object):
         GObject.Object.__init__(self)
         self.server = TuhiDBusServer()
         self.server.connect('bus-name-acquired', self._on_tuhi_bus_name_acquired)
+        self.server.connect('start-pairing-requested', self._on_start_pairing_requested)
         self.bluez = BlueZDeviceManager()
         self.bluez.connect('device-added', self._on_bluez_device_added)
 
@@ -145,6 +146,9 @@ class Tuhi(GObject.Object):
 
     def _on_tuhi_bus_name_acquired(self, dbus_server):
         self.bluez.connect_to_bluez()
+
+    def _on_start_pairing_requested(self, dbus_server):
+        self.bluez.start_discovery(30)
 
     def _on_bluez_device_added(self, manager, bluez_device):
         if bluez_device.vendor_id != WACOM_COMPANY_ID:

--- a/tuhi.py
+++ b/tuhi.py
@@ -142,6 +142,7 @@ class Tuhi(GObject.Object):
         self.bluez = BlueZDeviceManager()
         self.bluez.connect('device-added', self._on_bluez_device_added)
         self.bluez.connect('device-updated', self._on_bluez_device_updated)
+        self.bluez.connect('discovery-stopped', self._on_discovery_stopped)
 
         self.devices = {}
 
@@ -178,6 +179,9 @@ class Tuhi(GObject.Object):
             return
 
         self.server.add_pairing_device(bluez_device)
+
+    def _on_discovery_stopped(self, bluez_device):
+        self.server.reset_pairing_devices()
 
 
 def main(args):

--- a/tuhi.py
+++ b/tuhi.py
@@ -82,13 +82,19 @@ class TuhiDevice(GObject.Object):
         self._wacom_device.connect('drawing', self._on_drawing_received)
         self._wacom_device.connect('done', self._on_fetching_finished, bluez_device)
         self.drawings = []
+        self.pairing_mode = False
 
         bluez_device.connect('connected', self._on_bluez_device_connected)
         bluez_device.connect('disconnected', self._on_bluez_device_disconnected)
+        self._bluez_device = bluez_device
+
+    def connect_device(self):
+        self._bluez_device.connect_device()
 
     def _on_bluez_device_connected(self, bluez_device):
         logger.debug('{}: connected'.format(bluez_device.address))
-        self._wacom_device.start()
+        self._wacom_device.start(self.pairing_mode)
+        self.pairing_mode = False
 
     def _on_bluez_device_disconnected(self, bluez_device):
         logger.debug('{}: disconnected'.format(bluez_device.address))
@@ -139,6 +145,7 @@ class Tuhi(GObject.Object):
         self.server = TuhiDBusServer()
         self.server.connect('bus-name-acquired', self._on_tuhi_bus_name_acquired)
         self.server.connect('start-pairing-requested', self._on_start_pairing_requested)
+        self.server.connect('pair-device-requested', self._on_pair_device_requested)
         self.bluez = BlueZDeviceManager()
         self.bluez.connect('device-added', self._on_bluez_device_added)
         self.bluez.connect('device-updated', self._on_bluez_device_updated)
@@ -182,6 +189,18 @@ class Tuhi(GObject.Object):
 
     def _on_discovery_stopped(self, bluez_device):
         self.server.reset_pairing_devices()
+
+    def _on_pair_device_requested(self, manager, address):
+        bluez_device = self.server.get_pairing_device(address)
+        if bluez_device is None:
+            # FIXME: we should return the dbus method an error
+            return
+
+        tuhi_dbus_device = self.server.create_device(bluez_device)
+        d = TuhiDevice(bluez_device, tuhi_dbus_device)
+        d.pairing_mode = True
+        self.devices[bluez_device.address] = d
+        d.connect_device()
 
 
 def main(args):

--- a/tuhi.py
+++ b/tuhi.py
@@ -85,17 +85,13 @@ class TuhiDevice(GObject.Object):
 
         bluez_device.connect('connected', self._on_bluez_device_connected)
         bluez_device.connect('disconnected', self._on_bluez_device_disconnected)
-        bluez_device.connect_device()
 
     def _on_bluez_device_connected(self, bluez_device):
         logger.debug('{}: connected'.format(bluez_device.address))
         self._wacom_device.start()
 
     def _on_bluez_device_disconnected(self, bluez_device):
-        # FIXME: immediately try to reconnect, at least until the DBusServer
-        # is hooked up correctly
         logger.debug('{}: disconnected'.format(bluez_device.address))
-        bluez_device.connect_device()
 
     def _on_drawing_received(self, device, drawing):
         logger.debug('Drawing received')

--- a/tuhi.py
+++ b/tuhi.py
@@ -150,8 +150,19 @@ class Tuhi(GObject.Object):
     def _on_start_pairing_requested(self, dbus_server):
         self.bluez.start_discovery(30)
 
+    @classmethod
+    def _is_pairing_device(cls, bluez_device):
+        if bluez_device.vendor_id != WACOM_COMPANY_ID:
+            return False
+
+        manufacturer_data = bluez_device.get_manufacturer_data(WACOM_COMPANY_ID)
+        return len(manufacturer_data) == 4
+
     def _on_bluez_device_added(self, manager, bluez_device):
         if bluez_device.vendor_id != WACOM_COMPANY_ID:
+            return
+
+        if Tuhi._is_pairing_device(bluez_device):
             return
 
         tuhi_dbus_device = self.server.create_device(bluez_device)

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -140,6 +140,12 @@ class BlueZDevice(GObject.Object):
         return (self.interface.get_cached_property('Connected').unpack() and
                 self.interface.get_cached_property('ServicesResolved').unpack())
 
+    def get_manufacturer_data(self, vendor_id):
+        md = self.interface.get_cached_property('ManufacturerData')
+        if md is not None and vendor_id in md.keys():
+            return md[vendor_id]
+        return None
+
     def resolve(self, om):
         """
         Resolve the GattServices and GattCharacteristics. This function does

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -285,6 +285,37 @@ class BlueZDeviceManager(GObject.Object):
         for obj in self._om.get_objects():
             self._process_object(obj)
 
+    def _discovery_timeout_expired(self):
+        for obj in self._om.get_objects():
+            i = obj.get_interface(ORG_BLUEZ_ADAPTER1)
+            if i is None:
+                continue
+
+            objpath = obj.get_object_path()
+            i.StopDiscovery()
+            logger.debug('Discovery stopped on: {}'.format(objpath))
+
+        # FIXME: we should notify the client that the timeout expired
+        return False
+
+    def start_discovery(self, timeout):
+        """
+        Start discovery mode for the specified timeout.
+
+        A value of 0 for the timeout means infinite.
+        """
+        for obj in self._om.get_objects():
+            i = obj.get_interface(ORG_BLUEZ_ADAPTER1)
+            if i is None:
+                continue
+
+            objpath = obj.get_object_path()
+            i.StartDiscovery()
+            logger.debug('Discovery started on: {}'.format(objpath))
+        if timeout >= 0:
+            logger.debug('Setting the timeout to {}'.format(timeout))
+            GObject.timeout_add_seconds(timeout, self._discovery_timeout_expired)
+
     def _on_om_object_added(self, om, obj):
         """Callback for ObjectManager's object-added"""
         objpath = obj.get_object_path()

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -268,6 +268,8 @@ class BlueZDeviceManager(GObject.Object):
             (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         "device-updated":
             (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+        "discovery-stopped":
+            (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
     def __init__(self, **kwargs):
@@ -307,7 +309,7 @@ class BlueZDeviceManager(GObject.Object):
             i.StopDiscovery()
             logger.debug('Discovery stopped on: {}'.format(objpath))
 
-        # FIXME: we should notify the client that the timeout expired
+        self.emit('discovery-stopped')
         return False
 
     def start_discovery(self, timeout):

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -31,6 +31,11 @@ INTROSPECTION_XML = """
       <annotation name='org.freedesktop.DBus.Method.NoReply' value='true'/>
     </method>
 
+    <method name='Pair'>
+      <arg name='address' type='s' direction='in'/>
+      <arg name='result' type='i' direction='out'/>
+    </method>
+
   </interface>
 
   <interface name='org.freedesktop.tuhi1.Device'>
@@ -141,6 +146,8 @@ class TuhiDBusServer(GObject.Object):
             (GObject.SIGNAL_RUN_FIRST, None, ()),
         "start-pairing-requested":
             (GObject.SIGNAL_RUN_FIRST, None, ()),
+        "pair-device-requested":
+            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_STRING,)),
     }
 
     def __init__(self):
@@ -179,6 +186,10 @@ class TuhiDBusServer(GObject.Object):
         if methodname == 'StartPairing':
             self._start_pairing()
             invocation.return_value()
+        elif methodname == 'Pair':
+            self.emit('pair-device-requested', args[0])
+            result = GLib.Variant.new_int32(0)
+            invocation.return_value(GLib.Variant.new_tuple(result))
 
     def _property_read_cb(self, connection, sender, objpath, interface, propname):
         if interface != INTF_MANAGER:
@@ -218,3 +229,9 @@ class TuhiDBusServer(GObject.Object):
 
     def reset_pairing_devices(self):
         self._pairing_devices = {}
+
+    def get_pairing_device(self, address):
+        if address not in self._pairing_devices:
+            return None
+
+        return self._pairing_devices[address]

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -215,3 +215,6 @@ class TuhiDBusServer(GObject.Object):
             return
 
         self._pairing_devices[address] = bluez_device
+
+    def reset_pairing_devices(self):
+        self._pairing_devices = {}

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -23,6 +23,11 @@ INTROSPECTION_XML = """
     <property type='ao' name='Devices' access='read'>
       <annotation name='org.freedesktop.DBus.Property.EmitsChangedSignal' value='true'/>
     </property>
+
+    <method name='StartPairing'>
+      <annotation name='org.freedesktop.DBus.Method.NoReply' value='true'/>
+    </method>
+
   </interface>
 
   <interface name='org.freedesktop.tuhi1.Device'>
@@ -131,6 +136,8 @@ class TuhiDBusServer(GObject.Object):
     __gsignals__ = {
         "bus-name-acquired":
             (GObject.SIGNAL_RUN_FIRST, None, ()),
+        "start-pairing-requested":
+            (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
     def __init__(self):
@@ -161,8 +168,13 @@ class TuhiDBusServer(GObject.Object):
     def _bus_name_lost(self, connection, name):
         pass
 
-    def _method_cb(self):
-        pass
+    def _method_cb(self, connection, sender, objpath, interface, methodname, args, invocation):
+        if interface != INTF_MANAGER:
+            return None
+
+        if methodname == 'StartPairing':
+            self._start_pairing()
+            invocation.return_value()
 
     def _property_read_cb(self, connection, sender, objpath, interface, propname):
         if interface != INTF_MANAGER:
@@ -175,6 +187,9 @@ class TuhiDBusServer(GObject.Object):
 
     def _property_write_cb(self):
         pass
+
+    def _start_pairing(self):
+        self.emit("start-pairing-requested")
 
     def cleanup(self):
         Gio.bus_unown_name(self._dbus)


### PR DESCRIPTION
The most important one is the README change: it has the API.

I had to disable the automatic connect of the device as on the Slate, this creates an infinite loop.
So with this branch, we currently need to connect to the device through other mean (`bluetoothctl`).

I have not tested the Spark Code. And thinking of it, having `is_slate()` when both the Folio and the Slate and others have the same firmware is probably a bummer