### PR TITLE
Pairing devices, fourth attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ org.freedesktop.tuhi1.Device
 
       Returns a string representing the JSON data from the last drawings or
       the empty string if no data is available or the index is invalid.
+
+  Signal: ButtonPressRequired()
+      Sent when the user is expected to press the physical button on the
+      device. A client should display a notification in response, if the
+      user does not press the button during the (firmware-specific) timeout
+      the current operation will fail.
 ```
 
 JSON File Format

--- a/tuhi.py
+++ b/tuhi.py
@@ -75,12 +75,14 @@ class TuhiDevice(GObject.Object):
     real device) with the frontend DBusServer object that exports the device
     over Tuhi's DBus interface
     """
+
     def __init__(self, bluez_device, tuhi_dbus_device, paired=True):
         GObject.Object.__init__(self)
         self._tuhi_dbus_device = tuhi_dbus_device
         self._wacom_device = WacomDevice(bluez_device)
         self._wacom_device.connect('drawing', self._on_drawing_received)
         self._wacom_device.connect('done', self._on_fetching_finished, bluez_device)
+        self._wacom_device.connect('button-press-required', self._on_button_press_required)
         self.drawings = []
         self.paired = paired
 
@@ -138,6 +140,9 @@ class TuhiDevice(GObject.Object):
 
     def _on_fetching_finished(self, device, bluez_device):
         bluez_device.disconnect_device()
+
+    def _on_button_press_required(self, device):
+        self._tuhi_dbus_device.notify_button_press_required()
 
 
 class Tuhi(GObject.Object):

--- a/tuhi.py
+++ b/tuhi.py
@@ -85,17 +85,13 @@ class TuhiDevice(GObject.Object):
 
         bluez_device.connect('connected', self._on_bluez_device_connected)
         bluez_device.connect('disconnected', self._on_bluez_device_disconnected)
-        bluez_device.connect_device()
 
     def _on_bluez_device_connected(self, bluez_device):
         logger.debug('{}: connected'.format(bluez_device.address))
         self._wacom_device.start()
 
     def _on_bluez_device_disconnected(self, bluez_device):
-        # FIXME: immediately try to reconnect, at least until the DBusServer
-        # is hooked up correctly
         logger.debug('{}: disconnected'.format(bluez_device.address))
-        bluez_device.connect_device()
 
     def _on_drawing_received(self, device, drawing):
         logger.debug('Drawing received')

--- a/tuhi.py
+++ b/tuhi.py
@@ -163,8 +163,19 @@ class Tuhi(GObject.Object):
         self._pairing_stop_handler = None
         self.bluez.stop_discovery()
 
+    @classmethod
+    def _is_pairing_device(cls, bluez_device):
+        if bluez_device.vendor_id != WACOM_COMPANY_ID:
+            return False
+
+        manufacturer_data = bluez_device.get_manufacturer_data(WACOM_COMPANY_ID)
+        return manufacturer_data is not None and len(manufacturer_data) == 4
+
     def _on_bluez_device_added(self, manager, bluez_device):
         if bluez_device.vendor_id != WACOM_COMPANY_ID:
+            return
+
+        if Tuhi._is_pairing_device(bluez_device):
             return
 
         tuhi_dbus_device = self.server.create_device(bluez_device)

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -140,6 +140,12 @@ class BlueZDevice(GObject.Object):
         return (self.interface.get_cached_property('Connected').unpack() and
                 self.interface.get_cached_property('ServicesResolved').unpack())
 
+    def get_manufacturer_data(self, vendor_id):
+        md = self.interface.get_cached_property('ManufacturerData')
+        if md is not None and vendor_id in md.keys():
+            return md[vendor_id]
+        return None
+
     def resolve(self, om):
         """
         Resolve the GattServices and GattCharacteristics. This function does

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -95,6 +95,8 @@ class BlueZDevice(GObject.Object):
             (GObject.SIGNAL_RUN_FIRST, None, ()),
         "disconnected":
             (GObject.SIGNAL_RUN_FIRST, None, ()),
+        "updated":
+            (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
     def __init__(self, om, obj):
@@ -237,6 +239,8 @@ class BlueZDevice(GObject.Object):
         elif 'ServicesResolved' in properties:
             if properties['ServicesResolved']:
                 self.emit('connected')
+        elif 'RSSI' in properties:
+            self.emit('updated')
 
     def connect_gatt_value(self, uuid, callback):
         """
@@ -261,6 +265,8 @@ class BlueZDeviceManager(GObject.Object):
     """
     __gsignals__ = {
         "device-added":
+            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+        "device-updated":
             (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         "discovery-started":
             (GObject.SIGNAL_RUN_FIRST, None, ()),
@@ -343,6 +349,12 @@ class BlueZDeviceManager(GObject.Object):
 
         self.emit("discovery-stopped")
 
+    def _on_device_updated(self, device):
+        """Callback for Device's properties-changed"""
+        logger.debug('Object updated: {}'.format(device.name))
+
+        self.emit("device-updated", device)
+
     def _on_om_object_added(self, om, obj):
         """Callback for ObjectManager's object-added"""
         objpath = obj.get_object_path()
@@ -376,11 +388,11 @@ class BlueZDeviceManager(GObject.Object):
     def _process_adapter(self, obj):
         objpath = obj.get_object_path()
         logger.debug('Adapter: {}'.format(objpath))
-        # FIXME: call StartDiscovery if we want to pair
 
     def _process_device(self, obj):
         dev = BlueZDevice(self._om, obj)
         self.devices.append(dev)
+        dev.connect("updated", self._on_device_updated)
         self.emit("device-added", dev)
 
     def _process_characteristic(self, obj):

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -61,6 +61,8 @@ INTROSPECTION_XML = """
       <arg name='json' type='s' direction='out'/>
     </method>
 
+    <signal name='ButtonPressRequired' />
+
     <signal name='ListenComplete'>
        <arg name='status' type='i' />
     </signal>
@@ -161,6 +163,11 @@ class TuhiDBusDevice(GObject.Object):
 
     def add_drawing(self, drawing):
         self.drawings.append(drawing)
+
+    def notify_button_press_required(self):
+        logger.debug("Sending ButtonPressRequired signal")
+        self._connection.emit_signal(None, self.objpath, INTF_DEVICE,
+                                     "ButtonPressRequired", None)
 
 
 class TuhiDBusServer(GObject.Object):

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -41,8 +41,6 @@ ORIENTATION_UPSIDEDOWN_LANDSCAPE = 'epacsdnal'
 
 # FIXME: this should be generated once and stored for future use (dconf?)
 SMARTPAD_UUID = 'dead00beef00'
-SMARTPAD_UUID = '1d6adc5fac76'
-SMARTPAD_UUID = '4810d75d5d4d'
 
 
 def signed_char_to_int(v):

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -124,6 +124,8 @@ class WacomDevice(GObject.Object):
             (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         "done":
             (GObject.SIGNAL_RUN_FIRST, None, ()),
+        "button-press-required":
+            (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
     def __init__(self, device):
@@ -578,6 +580,7 @@ class WacomDevice(GObject.Object):
     def pair_device_slate(self):
         self.register_connection()
         logger.info("Press the button now to confirm")
+        self.emit('button-press-required')
         data = self.wait_nordic_data([0xe4, 0xb3], 10)
         if data.opcode == 0xb3:
             # generic ACK
@@ -604,6 +607,7 @@ class WacomDevice(GObject.Object):
         self.send_nordic_command(command=0xe3,
                                  arguments=[0x01])
         logger.info("Press the button now to confirm")
+        self.emit('button-press-required')
         # Wait for the button confirmation event, or any error
         data = self.wait_nordic_data([0xe4, 0xb3], 10)
         if data.opcode == 0xb3:

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -575,7 +575,7 @@ class WacomDevice(GObject.Object):
         except WacomEEAGAINException:
             logger.warning("no data, please make sure the LED is blue and the button is pressed to switch it back to green")
 
-    def register_device_slate(self):
+    def pair_device_slate(self):
         self.register_connection()
         logger.info("Press the button now to confirm")
         data = self.wait_nordic_data([0xe4, 0xb3], 10)
@@ -595,7 +595,7 @@ class WacomDevice(GObject.Object):
         logger.info(f'firmware is {fw_high}-{fw_low}')
         logger.info("pairing completed")
 
-    def register_device_spark(self):
+    def pair_device_spark(self):
         try:
             self.check_connection()
         except WacomWrongModeException:
@@ -620,11 +620,12 @@ class WacomDevice(GObject.Object):
         logger.info(f'firmware is {fw_high}-{fw_low}')
         logger.info("pairing completed")
 
-    def register_device(self):
+    def pair_device(self):
+        logger.debug("{}: pairing device".format(self.device.address))
         if self.is_slate():
-            self.register_device_slate()
+            self.pair_device_slate()
         else:
-            self.register_device_spark()
+            self.pair_device_spark()
 
     def run(self):
         if self._is_running:
@@ -635,7 +636,7 @@ class WacomDevice(GObject.Object):
         self._is_running = True
         try:
             if self._pairing_mode:
-                self.register_device()
+                self.pair_device()
             else:
                 self.retrieve_data()
         finally:


### PR DESCRIPTION
I had the approach from #4  working and then realised that we can't send message from the device during pairing. Which is a problem, because we need to know when to press the button to accept the pairing request. 

So the new approach is:
- have the PairableDevice signal carry an object path, but that object isn't in Manager.Devices
- call Pair() on that Device interface

This PR supersedes #4, but there's still a bit missing, even after pairing the device doesn't end up in the Devices list.