### PR TITLE
Per device listening

### DIFF
--- a/tuhi.py
+++ b/tuhi.py
@@ -119,6 +119,10 @@ class TuhiDevice(GObject.Object):
         self._tuhi_dbus_device = device
         self._tuhi_dbus_device.connect('pair-requested', self._on_pair_requested)
 
+    @property
+    def listening(self):
+        return self._tuhi_dbus_device.listening
+
     def connect_device(self):
         self._bluez_device.connect_device()
 
@@ -264,8 +268,12 @@ class Tuhi(GObject.Object):
                 d.dbus_device = self.server.create_device(d)
                 self.devices[bluez_device.address] = d
 
+        d = self.devices[bluez_device.address]
+
         if Tuhi._is_pairing_device(bluez_device):
             logger.debug('{}: call Pair() on device'.format(bluez_device.objpath))
+        elif d.listening:
+            d.connect_device()
 
 
 def main(args):

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -177,7 +177,7 @@ class TuhiDBusDevice(GObject.Object):
         logger.debug('{}: is paired {}'.format(device, device.paired))
         self.paired = device.paired
 
-    @property
+    @GObject.Property
     def listening(self):
         return len(self._listening_clients) > 0
 
@@ -198,7 +198,7 @@ class TuhiDBusDevice(GObject.Object):
         self._listening_clients[client] = s
         logger.debug('Listening started on {} for {}'.format(self.name, client))
 
-        # FIXME: notify the server to start discovery
+        self.notify('listening')
 
     def on_signal_cb(self, connection, sender, object_path, interface_name, node, out_user_data, user_data):
         name, old_owner, new_owner = out_user_data
@@ -217,7 +217,7 @@ class TuhiDBusDevice(GObject.Object):
         del(self._listening_clients[client])
         logger.debug('Listening stopped on {} for {}'.format(self.name, client))
 
-        # FIXME: notify the server to stop discovery
+        self.notify('listening')
 
     def _json_data(self, args):
         index = args[0]


### PR DESCRIPTION
This goes on top of #10.

Implementation of the per-device listen() mechanism with the `StartDiscovery()` internal call.

We internally discussed about using `StopDiscovery()` to clean up the `RSSI` property, but this only works if we are the only one controlling the discovery.
However, we can remove the `DuplicateData` filter which will provide us all the `RSSI` events even if they are the same than the previous ones.

There are still a few bits left:
 - [ ] there is not `ListeningStopped` signal emitted [Update: do we need one?]
 - [x] ~~if `bluetoothd.service` is restarted, the bluez devices do not have their `ManufacturerData` set, so the devices are not created~~
 - [x] ~~if `bluetoothd.service` is restarted, and `StartDiscovery()` is called by an other mean, the communication fail with the new device~~
 - [ ] probably something else