### PR TITLE
Listen() support, commandline tool extensions, bugfixing

### DIFF
--- a/tuhi-kete.py
+++ b/tuhi-kete.py
@@ -155,6 +155,7 @@ class TuhiKeteDevice(_DBusObject):
             if d.address == self.address:
                 self.is_pairing = False
                 print('{}: Pairing successful'.format(self))
+                self.manager.quit()
 
 
 class TuhiKeteManager(_DBusObject):

--- a/tuhi-kete.py
+++ b/tuhi-kete.py
@@ -190,8 +190,13 @@ class TuhiKeteManager(_DBusObject):
     def searching(self):
         return self._searching
 
+    @searching.setter
+    def searching(self, value):
+        self._searching = value
+
     def start_search(self):
         self._pairable_devices = {}
+        self.searching = True
         self.proxy.StartSearch()
 
     def stop_search(self):
@@ -266,9 +271,10 @@ class Searcher(GObject.Object):
             self.manager.stop_search()
 
     def _on_notify_search(self, manager, pspec):
-        logger.info('Search timeout')
-        if not self.is_pairing:
-            self.manager.quit()
+        if not manager.searching:
+            logger.info('Search timeout')
+            if not self.is_pairing:
+                self.manager.quit()
 
     def _on_pairable_device(self, manager, device):
         print('Pairable device: {}'.format(device))

--- a/tuhi.py
+++ b/tuhi.py
@@ -289,6 +289,7 @@ class Tuhi(GObject.Object):
         d = self.devices[bluez_device.address]
 
         if Tuhi._is_pairing_device(bluez_device):
+            d.paired = False
             logger.debug('{}: call Pair() on device'.format(bluez_device.objpath))
         elif d.listening:
             d.connect_device()

--- a/tuhi.py
+++ b/tuhi.py
@@ -119,6 +119,10 @@ class TuhiDevice(GObject.Object):
         self._tuhi_dbus_device = device
         self._tuhi_dbus_device.connect('pair-requested', self._on_pair_requested)
 
+    @property
+    def listening(self):
+        return self._tuhi_dbus_device.listening
+
     def connect_device(self):
         self._bluez_device.connect_device()
 
@@ -264,8 +268,12 @@ class Tuhi(GObject.Object):
                 d.dbus_device = self.server.create_device(d)
                 self.devices[bluez_device.address] = d
 
+        d = self.devices[bluez_device.address]
+
         if Tuhi._is_pairing_device(bluez_device):
             logger.debug('{}: call Pair() on device'.format(bluez_device.objpath))
+        elif d.listening:
+            d.connect_device()
 
 
 def main(args):

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -209,7 +209,13 @@ class BlueZDevice(GObject.Object):
         i.Connect(result_handler=self._on_connect_result)
 
     def _on_connect_result(self, obj, result, user_data):
-        if isinstance(result, Exception):
+        if (isinstance(result, GLib.Error) and
+                result.domain == 'g-io-error-quark' and
+                result.code == Gio.IOErrorEnum.DBUS_ERROR and
+                Gio.dbus_error_get_remote_error(result) == 'org.bluez.Error.Failed' and
+                'Operation already in progress' in result.message):
+                    logger.debug('{}: Already connecting'.format(self.address))
+        elif isinstance(result, Exception):
             logger.error('Connection failed: {}'.format(result))
 
     def disconnect_device(self):

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -120,7 +120,10 @@ class BlueZDevice(GObject.Object):
 
     @property
     def name(self):
-        return self.interface.get_cached_property('Name').unpack()
+        try:
+            return self.interface.get_cached_property('Name').unpack()
+        except AttributeError:
+            return 'UNKNOWN'
 
     @property
     def address(self):

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -206,6 +206,8 @@ class TuhiDBusDevice(GObject.Object):
         self.emit('pair-requested')
 
     def _on_device_paired(self, device, pspec):
+        if self.paired == device.paired:
+            return
         self.paired = device.paired
 
     def _start_listening(self, connection, sender):

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -163,7 +163,6 @@ class TuhiDBusDevice(GObject.Object):
         self.emit('pair-requested')
 
     def _on_device_paired(self, device, pspec):
-        logger.debug('{}: is paired {}'.format(device, device.paired))
         self.paired = device.paired
 
     def _listen(self):
@@ -187,6 +186,9 @@ class TuhiDBusDevice(GObject.Object):
         logger.debug("Sending ButtonPressRequired signal")
         self._connection.emit_signal(None, self.objpath, INTF_DEVICE,
                                      "ButtonPressRequired", None)
+
+    def __repr__(self):
+        return "{} - {}".format(self.objpath, self.name)
 
 
 class TuhiDBusServer(GObject.Object):
@@ -307,7 +309,6 @@ class TuhiDBusServer(GObject.Object):
         return dev
 
     def _on_device_paired(self, device, param):
-        logger.debug('dbus server {}: is paired {}'.format(device, device.paired))
         props = GLib.VariantBuilder(GLib.VariantType('a{sv}'))
 
         objpaths = GLib.Variant.new_array(GLib.VariantType('o'),

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -273,6 +273,23 @@ class TuhiDBusDevice(GObject.Object):
     def add_drawing(self, drawing):
         self.drawings.append(drawing)
 
+        props = GLib.VariantBuilder(GLib.VariantType('a{sv}'))
+        de = GLib.Variant.new_dict_entry(GLib.Variant.new_string('DrawingsAvailable'),
+                                         GLib.Variant.new_variant(
+                                             GLib.Variant.new_uint32(len(self.drawings))))
+        props.add_value(de)
+        props = props.end()
+        inval_props = GLib.VariantBuilder(GLib.VariantType('as'))
+        inval_props = inval_props.end()
+
+        self._connection.emit_signal(None, self.objpath,
+                                     "org.freedesktop.DBus.Properties",
+                                     "PropertiesChanged",
+                                     GLib.Variant.new_tuple(
+                                         GLib.Variant.new_string(INTF_DEVICE),
+                                         props,
+                                         inval_props))
+
     def notify_button_press_required(self):
         logger.debug("Sending ButtonPressRequired signal")
         self._connection.emit_signal(None, self.objpath, INTF_DEVICE,

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -232,8 +232,8 @@ class TuhiDBusDevice(GObject.Object):
         self._listening_client = (sender, s)
         logger.debug('Listening started on {} for {}'.format(self.name, sender))
 
-        # FIXME: notify the server to start discovery
-        self.listening = True
+        self._listening = True
+        self.notify('listening')
 
     def _on_name_owner_changed_signal_cb(self, connection, sender, object_path,
                                          interface_name, node,
@@ -252,13 +252,14 @@ class TuhiDBusDevice(GObject.Object):
         self._listening_client = None
         logger.debug('Listening stopped on {} for {}'.format(self.name, sender))
 
-        # FIXME: notify the server to stop discovery
+        self.notify('listening')
 
         status = GLib.Variant.new_int32(0)
         status = GLib.Variant.new_tuple(status)
         connection.emit_signal(sender, self.objpath, INTF_DEVICE,
                                "ListeningStopped", status)
         self.listening = False
+        self.notify('listening')
 
     def _json_data(self, args):
         index = args[0]

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -368,7 +368,7 @@ class WacomDevice(GObject.Object):
                                              expected_opcode=0xcf)
         # logger.debug(f'cc returned {data} ')
         count = int.from_bytes(data[0:4], byteorder='little')
-        str_timestamp = ''.join([hex(d)[2:] for d in data[4:]])
+        str_timestamp = ''.join(['{:02x}'.format(d) for d in data[4:]])
         timestamp = time.strptime(str_timestamp, "%y%m%d%H%M%S")
         return count, timestamp
 
@@ -383,7 +383,7 @@ class WacomDevice(GObject.Object):
             data = self.wait_nordic_data(0xcd, 5)
             # logger.debug(f'cc returned {data} ')
 
-        str_timestamp = ''.join([hex(d)[2:] for d in data])
+        str_timestamp = ''.join(['{:02x}'.format(d) for d in data])
         timestamp = time.strptime(str_timestamp, "%y%m%d%H%M%S")
         return count, timestamp
 


### PR DESCRIPTION
Parts of this are the wip/listen branch from #12 with a few changes/additions like the dbus property changes, etc. Biggest change is in design: only one client is allowed to start/stop listen, the rest gets EAGAIN and needs to hook onto the property. This makes the most sense imo, given that having two clients listen to the device at the same time is arguably pointless (esp. if we cache the jsons).

This branch now works a bit better when a device switches from "known" to "in pairing mode now", but there are still a few issues with all that.

Supersedes #12 