### PR TITLE
wacom: set the device time to UTC time on pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ org.freedesktop.tuhi1.Device
 
   Property: DrawingsAvailable (at)
       An array of timestamps of the available drawings. The timestamp of
-      each drawing can be used as argument to GetJSONData().
+      each drawing can be used as argument to GetJSONData(). Timestamps are
+      in seconds since the Epoch and may be used to display information to
+      the user or sort data.
       Read-only
 
   Property: Listening (b)

--- a/tools/tuhi-kete.py
+++ b/tools/tuhi-kete.py
@@ -473,7 +473,7 @@ class Fetcher(Worker):
         for idx in self.indices:
             jsondata = self.device.json(idx)
             data = json.loads(jsondata)
-            t = time.gmtime(data['timestamp'])
+            t = time.localtime(data['timestamp'])
             t = time.strftime('%Y-%m-%d-%H-%M', t)
             path = f'{data["devicename"]}-{t}.svg'
             self.json_to_svg(data, path)

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -13,6 +13,7 @@
 
 
 import binascii
+import calendar
 import logging
 import threading
 import time
@@ -268,7 +269,8 @@ class WacomDevice(GObject.Object):
                                       expected_opcode=0xb3)
 
     def set_time(self):
-        self.current_time = time.strftime("%y%m%d%H%M%S")
+        # Device time is UTC
+        self.current_time = time.strftime("%y%m%d%H%M%S", time.gmtime())
         args = [int(i) for i in binascii.unhexlify(self.current_time)]
         self.send_nordic_command_sync(command=0xb6,
                                       expected_opcode=0xb3,
@@ -463,7 +465,7 @@ class WacomDevice(GObject.Object):
         x, y, p = 0, 0, 0
         dx, dy, dp = 0, 0, 0
 
-        timestamp = int(time.mktime(timestamp))
+        timestamp = int(calendar.timegm(timestamp))
         drawings = []
         drawing = None
         stroke = None


### PR DESCRIPTION
And let us handle the local time zone conversions in the client, because
having timestamps in localtime in the daemon is confusing and error-prone (how
is the client supposed to know what localtime was?)