### PR TITLE
fw fixes

### DIFF
--- a/tools/tuhi-kete.py
+++ b/tools/tuhi-kete.py
@@ -15,6 +15,7 @@ from gi.repository import GObject, Gio, GLib
 import sys
 import argparse
 import cmd
+import errno
 import os
 import json
 import logging
@@ -193,8 +194,10 @@ class TuhiKeteDevice(_DBusObject):
             logger.info(f'{self}: Press button on device now')
         elif signal == 'ListeningStopped':
             err = parameters[0]
-            if err < 0:
-                logger.error(f'{self}: an error occured: {os.strerror(err)}')
+            if err == -errno.EACCES:
+                logger.error(f'{self}: wrong device, please redo pairing.')
+            elif err < 0:
+                logger.error(f'{self}: an error occured: {os.strerror(-err)}')
             self.notify('listening')
 
     def _on_properties_changed(self, proxy, changed_props, invalidated_props):

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -35,6 +35,9 @@ WACOM_CHRC_LIVE_PEN_DATA_UUID = '00001524-1212-efde-1523-785feabcd123'
 WACOM_OFFLINE_SERVICE_UUID = 'ffee0001-bbaa-9988-7766-554433221100'
 WACOM_OFFLINE_CHRC_PEN_DATA_UUID = 'ffee0003-bbaa-9988-7766-554433221100'
 
+MYSTERIOUS_NOTIFICATION_SERVICE_UUID = '3a340720-c572-11e5-86c5-0002a5d5c51b'
+MYSTERIOUS_NOTIFICATION_CHRC_UUID = '3a340721-c572-11e5-86c5-0002a5d5c51b'
+
 WACOM_SLATE_WIDTH = 21600
 WACOM_SLATE_HEIGHT = 14800
 
@@ -131,6 +134,8 @@ class WacomDevice(GObject.Object):
                                   self._on_pen_data_received)
         device.connect_gatt_value(NORDIC_UART_CHRC_RX_UUID,
                                   self._on_nordic_data_received)
+        device.connect_gatt_value(MYSTERIOUS_NOTIFICATION_CHRC_UUID,
+                                  self._on_mysterious_data_received)
 
     @GObject.Property
     def uuid(self):
@@ -138,7 +143,10 @@ class WacomDevice(GObject.Object):
         return self._uuid
 
     def is_slate(self):
-        return self.name == 'Bamboo Slate'
+        return MYSTERIOUS_NOTIFICATION_CHRC_UUID in self.device.characteristics
+
+    def _on_mysterious_data_received(self, name, value):
+        self.fw_logger.debug(f'mysterious: {binascii.hexlify(bytes(value))}')
 
     def _on_pen_data_changed(self, name, value):
         logger.debug(binascii.hexlify(bytes(value)))

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -302,7 +302,7 @@ class WacomDevice(GObject.Object):
         data = self.send_nordic_command_sync(command=0xb7,
                                              expected_opcode=0xb8,
                                              arguments=(arg,))
-        fw = ''.join([hex(d)[2:] for d in data])
+        fw = ''.join([hex(d)[2:] for d in data[1:]])
         return fw.upper()
 
     def bb_command(self):


### PR DESCRIPTION
When the device is not paired anymore, we should output something related in kete.

The second part of this PR is an attempt to forward support the other devices using the same protocol.

The Folio and the Slate are supposed to have similar firmwares (just the casing differs), so it's unfair to force the name to be `Bamboo Slate` to have the device working. Hopefully we will get support for the Folio and the Intuos Pro Paper Edition for free.