### PR TITLE
Exit the shell when the dbus name vanishes

### DIFF
--- a/tools/tuhi-kete.py
+++ b/tools/tuhi-kete.py
@@ -332,8 +332,6 @@ class Worker(GObject.Object):
     def __init__(self, manager, args=None):
         GObject.GObject.__init__(self)
         self.manager = manager
-        self._run = self.run
-        self._stop = self.stop
 
     def run(self):
         pass
@@ -342,12 +340,12 @@ class Worker(GObject.Object):
         pass
 
     def start(self):
-        self._run()
+        self.run()
 
         if self.need_mainloop:
             self.manager.run()
 
-        self._stop()
+        self.stop()
 
 
 class Searcher(Worker):


### PR DESCRIPTION
Still requires *some* user interaction, but at least anything the user does after the name vanishes causes kete to quit.