### PR TITLE
flatpak bundle of tuhi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.flatpak*
+flatpak*
 tuhi.egg-info
 __pycache__
 *.swp

--- a/org.freedesktop.tuhi.json
+++ b/org.freedesktop.tuhi.json
@@ -1,0 +1,106 @@
+{
+    "id": "org.freedesktop.tuhi",
+    "command": "/app/bin/tuhi",
+    "runtime": "org.freedesktop.Platform",
+    "sdk": "org.freedesktop.Sdk",
+    "runtime-version": "1.6",
+    "cleanup": [ "/cache",
+                 "/include",
+                 "/lib/pkgconfig",
+                 "/man",
+                 "/share/aclocal",
+                 "/share/devhelp",
+                 "/share/gir-1.0",
+                 "/share/gtk-doc",
+                 "/share/man",
+                 "/share/pkgconfig",
+                 "/share/vala",
+                 "/lib/systemd",
+                 "*.la", "*.a" ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g"
+    },
+    "finish-args": [
+        "--system-talk-name=org.bluez",
+        "--own-name=org.freedesktop.tuhi1"
+    ],
+    "modules": [
+        {
+            "name": "cpython",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.python.org/ftp/python/3.6.4/Python-3.6.4.tar.xz",
+                    "sha256": "159b932bf56aeaa76fd66e7420522d8c8853d486b8567c459b84fe2ed13bcaba"
+                }
+            ]
+        },
+        {
+            "name": "pycairo",
+            "build-options" : {
+                "env": {
+                    "PYTHON": "/app/bin/python3"
+                }
+            },
+            "buildsystem": "simple",
+            "build-commands": [
+                "python3 ./setup.py build",
+                "python3 ./setup.py install"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/pygobject/pycairo/releases/download/v1.14.1/pycairo-1.14.1.tar.gz",
+                    "sha256": "0d13a0a6eeaf0c357db04392943eb9b25767445608d31dde1307f003f68c5754"
+                }
+            ]
+        },
+        {
+            "name": "pygobject",
+            "config-opts": ["--enable-compile-warnings=minimum"],
+            "build-options" : {
+                "env": {
+                    "PYTHON": "/app/bin/python3"
+                }
+            },
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://gitlab.gnome.org/GNOME/pygobject.git"
+                }
+            ]
+        },
+        {
+            "name": "pyxdg",
+            "buildsystem": "simple",
+            "build-options" : {
+                "env": {
+                    "PYTHON": "/app/bin/python3"
+                }
+            },
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "git://anongit.freedesktop.org/xdg/pyxdg"
+                }
+            ],
+            "build-commands": [
+                "python3 setup.py install --verbose"
+            ]
+        },
+        {
+            "name": "tuhi",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "git",
+                    "path": "."
+                }
+            ],
+            "build-commands": [
+                "python3 setup.py install --verbose"
+            ]
+        }
+    ]
+}

--- a/tools/tuhi-kete.py
+++ b/tools/tuhi-kete.py
@@ -270,7 +270,7 @@ class TuhiKeteDevice(_DBusObject):
 class TuhiKeteManager(_DBusObject):
     __gsignals__ = {
         'pairable-device':
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
     }
 
     def __init__(self):

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -16,7 +16,7 @@ import enum
 import logging
 import sys
 import time
-from gi.repository import GObject
+from gi.repository import GObject, GLib
 
 from tuhi.dbusserver import TuhiDBusServer
 from tuhi.ble import BlueZDeviceManager
@@ -46,7 +46,7 @@ class TuhiDevice(GObject.Object):
         # Signal sent when an error occurs on the device itself.
         # Argument is a Wacom*Exception
         'device-error':
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
     }
 
     BATTERY_UPDATE_MIN_INTERVAL = 300
@@ -199,9 +199,9 @@ class TuhiDevice(GObject.Object):
 class Tuhi(GObject.Object):
     __gsignals__ = {
         'device-added':
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         'device-connected':
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
     }
 
     def __init__(self):
@@ -222,7 +222,7 @@ class Tuhi(GObject.Object):
         self.devices = {}
 
         self._search_stop_handler = None
-        self.mainloop = GObject.MainLoop()
+        self.mainloop = GLib.MainLoop()
 
     def _on_tuhi_bus_name_acquired(self, dbus_server):
         self.bluez.connect_to_bluez()

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -92,11 +92,11 @@ class BlueZDevice(GObject.Object):
     '''
     __gsignals__ = {
         'connected':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
         'disconnected':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
         'updated':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     def __init__(self, om, obj):
@@ -118,29 +118,29 @@ class BlueZDevice(GObject.Object):
         if self.connected:
             self.emit('connected')
 
-    @GObject.property
+    @GObject.Property
     def name(self):
         try:
             return self.interface.get_cached_property('Name').unpack()
         except AttributeError:
             return 'UNKNOWN'
 
-    @GObject.property
+    @GObject.Property
     def address(self):
         return self.interface.get_cached_property('Address').unpack()
 
-    @GObject.property
+    @GObject.Property
     def uuids(self):
         return self.interface.get_cached_property('UUIDs').unpack()
 
-    @GObject.property
+    @GObject.Property
     def vendor_id(self):
         md = self.interface.get_cached_property('ManufacturerData')
         if md is not None:
             return md.keys()[0]
         return None
 
-    @GObject.property
+    @GObject.Property
     def connected(self):
         return (self.interface.get_cached_property('Connected').unpack() and
                 self.interface.get_cached_property('ServicesResolved').unpack())
@@ -274,13 +274,13 @@ class BlueZDeviceManager(GObject.Object):
     '''
     __gsignals__ = {
         'device-added':
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT, GObject.TYPE_BOOLEAN)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT, GObject.TYPE_BOOLEAN)),
         'device-updated':
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         'discovery-started':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
         'discovery-stopped':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     def __init__(self, **kwargs):

--- a/tuhi/config.py
+++ b/tuhi/config.py
@@ -40,7 +40,7 @@ class TuhiConfig(GObject.Object):
         self._devices = {}
         self._scan_config_dir()
 
-    @GObject.property
+    @GObject.Property
     def devices(self):
         '''
         Returns a dictionary with the bluetooth address as key

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -135,7 +135,7 @@ class TuhiDBusDevice(_TuhiDBus):
     '''
     __gsignals__ = {
         'pair-requested':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     def __init__(self, device, connection):
@@ -361,18 +361,18 @@ class TuhiDBusServer(_TuhiDBus):
     '''
     __gsignals__ = {
         'bus-name-acquired':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
         'bus-name-lost':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
 
         # Signal arguments:
         #    search_stop_handler(status)
         #        to be called when the search process has terminated, with
         #        an integer status code (0 == success, negative errno)
         'search-start-requested':
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         'search-stop-requested':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
     def __init__(self):

--- a/tuhi/drawing.py
+++ b/tuhi/drawing.py
@@ -88,7 +88,7 @@ class Drawing(GObject.Object):
 
     # The way we're building drawings, we don't need to change the current
     # stroke at runtime, so this is read-ony
-    @GObject.property
+    @GObject.Property
     def current_stroke(self):
         return self.strokes[self._current_stroke]
 

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -104,14 +104,14 @@ class WacomDevice(GObject.Object):
 
     __gsignals__ = {
         'drawing':
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         'done':
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT, )),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT, )),
         'button-press-required':
-            (GObject.SIGNAL_RUN_FIRST, None, ()),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
         # battery level in %, boolean for is-charging
         "battery-status":
-            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_BOOLEAN)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_BOOLEAN)),
     }
 
     def __init__(self, device, uuid=None):


### PR DESCRIPTION
on top of #58 , because I am lazy.

Provide a json that can be used by flatpak-builder to create the flatpak that runs tuhi.
Given #62, kete is not part of this journey, but calling kete from the project allows to talk to the sandboxed tuhi, which is nice.