### PR TITLE
flatpak: ship tuhi-kete in the sandbox

### DIFF
--- a/org.freedesktop.tuhi.json
+++ b/org.freedesktop.tuhi.json
@@ -45,8 +45,8 @@
             },
             "buildsystem": "simple",
             "build-commands": [
-                "python3 ./setup.py build",
-                "python3 ./setup.py install"
+                "python3 ./setup.py sdist",
+                "pip3 install dist/*.tar.gz"
             ],
             "sources": [
                 {
@@ -74,11 +74,6 @@
         {
             "name": "pyxdg",
             "buildsystem": "simple",
-            "build-options" : {
-                "env": {
-                    "PYTHON": "/app/bin/python3"
-                }
-            },
             "sources": [
                 {
                     "type": "git",
@@ -86,7 +81,37 @@
                 }
             ],
             "build-commands": [
-                "python3 setup.py install --verbose"
+                "python3 ./setup.py sdist",
+                "pip3 install dist/*.tar.gz"
+            ]
+        },
+        {
+            "name": "python-pyparsing",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://downloads.sourceforge.net/pyparsing/pyparsing-2.1.10.tar.gz",
+                    "sha512": "21af73d6f479d52746f269c8fbaf90c1107a8aec756d30af8c7c4e6a2ff0ea9659cc07816b7ea19286bc12d43497f5e8e63351453bf18daf6a1cb380a195532e"
+                }
+            ],
+            "build-commands": [
+                "python3 ./setup.py sdist",
+                "pip3 install dist/*.tar.gz"
+            ]
+        },
+        {
+            "name": "python-svgwrite",
+            "buildsystem": "simple",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/mozman/svgwrite.git"
+                }
+            ],
+            "build-commands": [
+                "python3 ./setup.py sdist",
+                "pip3 install dist/*.tar.gz"
             ]
         },
         {
@@ -100,6 +125,11 @@
             ],
             "build-commands": [
                 "python3 setup.py install --verbose"
+            ],
+            "post-install": [
+                "cp tools/tuhi-kete.py /app/lib/python3.6/site-packages/tuhi_kete.py",
+                "cp tools/tuhi-kete-sandboxed.py /app/bin/tuhi-kete",
+                "chmod +x /app/bin/tuhi-kete"
             ]
         }
     ]

--- a/tools/tuhi-kete-sandboxed.py
+++ b/tools/tuhi-kete-sandboxed.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+
+import sys
+import multiprocessing
+
+
+def start_or_not_tuhi(queue):
+    should_start = queue.get()
+
+    if not should_start:
+        return
+
+    import tuhi.base
+    tuhi.base.main(['tuhi'])
+
+
+def main(args=sys.argv):
+
+    queue = multiprocessing.Queue()
+
+    tuhi_process = multiprocessing.Process(target=start_or_not_tuhi, args=(queue,))
+    tuhi_process.daemon = True
+    tuhi_process.start()
+
+    # import after spawning the process, or the 2 processes will fight for GLib
+    import tuhi_kete
+    from gi.repository import Gio, GLib
+
+    # connect to the session
+    try:
+        connection = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+    except GLib.Error as e:
+        if (e.domain == 'g-io-error-quark' and
+                e.code == Gio.IOErrorEnum.DBUS_ERROR):
+            raise tuhi_kete.DBusError(e.message)
+        else:
+            raise e
+
+    # attempt to connect to tuhi
+    try:
+        proxy = Gio.DBusProxy.new_sync(connection,
+                                       Gio.DBusProxyFlags.NONE, None,
+                                       tuhi_kete.TUHI_DBUS_NAME,
+                                       tuhi_kete.ROOT_PATH,
+                                       tuhi_kete.ORG_FREEDESKTOP_TUHI1_MANAGER,
+                                       None)
+    except GLib.Error as e:
+        if (e.domain == 'g-io-error-quark' and
+                e.code == Gio.IOErrorEnum.DBUS_ERROR):
+            raise tuhi_kete.DBusError(e.message)
+        else:
+            raise e
+
+    started = proxy.get_name_owner() is not None
+
+    if not started:
+        print(f'No-one is handling {tuhi_kete.TUHI_DBUS_NAME}, attempting to start a daemon')
+
+    queue.put(not started)
+
+    tuhi_kete.main(args)
+
+
+if __name__ == '__main__':
+    main(sys.argv)


### PR DESCRIPTION
To be able to run tuhi-kete, we need a tuhi server running. Provide a script that spawns one if none is running.

To not have the 2 processes fighting for GLib and the mainloop, we need to first spawn a new process, and then attach the GLib and other to them. Thus the `lock` and `queue` in place.

Running simple 'python3 setup.py --install' started to go havoc by complaining that `/app/lib/python3.6/site-packages/easy-install.pth` was read-only.

The solution mentioned in https://github.com/flatpak/flatpak-builder/issues/5 didn't do the trick.

So using https://stackoverflow.com/questions/6301003/stopping-setup-py-from-installing-as-egg/27175492#27175492 as a trick to install the dependencies without the egg part

To start tuhi-kete:
`$> flatpak run --command=tuhi-kete org.freedesktop.tuhi`

Note that currently the fetched files are not available outside of the sandbox

Related to #62