### PR TITLE
base: require Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,7 @@ setup(name='tuhi',
           'Development Status :: 3 - Alpha',
           'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
           'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.6'
       ],
+      python_requires='>=3.6'
       )

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -321,6 +321,9 @@ class Tuhi(GObject.Object):
 
 
 def main(args=sys.argv):
+    if sys.version_info < (3, 6):
+        sys.exit('Python 3.6 or later required')
+
     desc = 'Daemon to extract the pen stroke data from Wacom SmartPad devices'
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument('-v', '--verbose',


### PR DESCRIPTION
Instead of failing with a syntax error on format strings, actually bail out
instead. Likewise for setup.py, require 3.6 and add this to the classifiers
too while we're there.

Related to #71