### PR TITLE
Split out the different protocols in subclasses

### DIFF
--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -167,7 +167,10 @@ class TuhiDevice(GObject.Object):
         self._tuhi_dbus_device.notify_button_press_required()
 
     def _on_uuid_updated(self, wacom_device, pspec, bluez_device):
-        self.config.new_device(bluez_device.address, wacom_device.uuid)
+        protocol = TuhiConfig.Protocol.SLATE
+        if wacom_device.is_spark():
+            protocol = TuhiConfig.Protocol.SPARK
+        self.config.new_device(bluez_device.address, wacom_device.uuid, protocol)
         self.registered = True
 
     def _on_listening_updated(self, dbus_device, pspec):
@@ -287,7 +290,7 @@ class Tuhi(GObject.Object):
             if uuid is None:
                 logger.info(f'{bluez_device.address}: device without config, must be registered first')
                 return
-            logger.debug(f'{bluez_device.address}: UUID {uuid}')
+            logger.debug(f'{bluez_device.address}: UUID {uuid} protocol: {config["Protocol"]}')
 
         # create the device if unknown from us
         if bluez_device.address not in self.devices:

--- a/tuhi/config.py
+++ b/tuhi/config.py
@@ -38,6 +38,13 @@ class TuhiConfig(GObject.Object):
         SLATE = 2
         INTUOS_PRO = 3
 
+        @classmethod
+        def from_string(cls, e):
+            for attr in [a for a in dir(cls) if not a.startswith('__')]:
+                if e in ('Protocol.' + attr, attr):
+                    return getattr(cls, attr)
+            return TuhiConfig.Protocol.UNKNOWN
+
     def __init__(self):
         GObject.Object.__init__(self)
         try:

--- a/tuhi/config.py
+++ b/tuhi/config.py
@@ -16,6 +16,7 @@ from gi.repository import GObject
 import xdg.BaseDirectory
 import os
 import configparser
+import enum
 import re
 import logging
 from .drawing import Drawing
@@ -30,6 +31,13 @@ def is_btaddr(addr):
 
 
 class TuhiConfig(GObject.Object):
+
+    class Protocol(enum.Enum):
+        UNKNOWN = 0
+        SPARK = 1
+        SLATE = 2
+        INTUOS_PRO = 3
+
     def __init__(self):
         GObject.Object.__init__(self)
         try:
@@ -67,9 +75,11 @@ class TuhiConfig(GObject.Object):
                 self._purge_drawings(entry)
 
                 assert config['Device']['Address'] == entry.name
+                if 'Protocol' not in config['Device']:
+                    config['Device']['Protocol'] = str(TuhiConfig.Protocol.UNKNOWN)
                 self._devices[entry.name] = config['Device']
 
-    def new_device(self, address, uuid):
+    def new_device(self, address, uuid, protocol):
         assert is_btaddr(address)
         assert len(uuid) == 12
 
@@ -92,6 +102,7 @@ class TuhiConfig(GObject.Object):
         config['Device'] = {
             'Address': address,
             'UUID': uuid,
+            'Protocol': protocol,
         }
 
         with open(path, 'w') as configfile:

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -21,6 +21,7 @@ import uuid
 import errno
 from gi.repository import GObject
 from .drawing import Drawing
+from .config import TuhiConfig
 
 logger = logging.getLogger('tuhi.wacom')
 
@@ -94,10 +95,9 @@ class WacomCorruptDataException(WacomException):
     errno = errno.EPROTO
 
 
-class WacomDevice(GObject.Object):
+class WacomProtocol(GObject.Object):
     '''
-    Class to communicate with the Wacom device. Communication is handled in
-    a separate thread.
+    Internal class to handle the communication with the Wacom device.
 
     :param device: the BlueZDevice object that is this wacom device
     '''
@@ -105,8 +105,6 @@ class WacomDevice(GObject.Object):
     __gsignals__ = {
         'drawing':
             (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
-        'done':
-            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT, )),
         'button-press-required':
             (GObject.SignalFlags.RUN_FIRST, None, ()),
         # battery level in %, boolean for is-charging
@@ -114,19 +112,17 @@ class WacomDevice(GObject.Object):
             (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_BOOLEAN)),
     }
 
-    def __init__(self, device, uuid=None):
+    def __init__(self, device, uuid):
         GObject.Object.__init__(self)
         self.device = device
         self.nordic_answer = None
         self.pen_data_buffer = []
         self.orientation = ORIENTATION_PORTRAIT
-        self.thread = None
         self.width = WACOM_SLATE_WIDTH
         self.height = WACOM_SLATE_HEIGHT
         self.name = device.name
         self._uuid = uuid
         self.fw_logger = logging.getLogger('tuhi.fw')
-        self._is_running = False
 
         device.connect_gatt_value(WACOM_CHRC_LIVE_PEN_DATA_UUID,
                                   self._on_pen_data_changed)
@@ -136,11 +132,6 @@ class WacomDevice(GObject.Object):
                                   self._on_nordic_data_received)
         device.connect_gatt_value(MYSTERIOUS_NOTIFICATION_CHRC_UUID,
                                   self._on_mysterious_data_received)
-
-    @GObject.Property
-    def uuid(self):
-        assert self._uuid is not None
-        return self._uuid
 
     def is_spark(self):
         return MYSTERIOUS_NOTIFICATION_CHRC_UUID not in self.device.characteristics
@@ -265,13 +256,13 @@ class WacomDevice(GObject.Object):
         return args
 
     def check_connection(self):
-        args = [int(i) for i in binascii.unhexlify(self.uuid)]
+        args = [int(i) for i in binascii.unhexlify(self._uuid)]
         self.send_nordic_command_sync(command=0xe6,
                                       expected_opcode=0xb3,
                                       arguments=args)
 
     def register_connection(self):
-        args = [int(i) for i in binascii.unhexlify(self.uuid)]
+        args = [int(i) for i in binascii.unhexlify(self._uuid)]
         self.send_nordic_command(command=0xe7,
                                  arguments=args)
 
@@ -619,29 +610,95 @@ class WacomDevice(GObject.Object):
         fw_low = self.get_firmware_version(1)
         logger.info(f'firmware is {fw_high}-{fw_low}')
 
+
+class WacomDevice(GObject.Object):
+    '''
+    Class to communicate with the Wacom device. Communication is handled in
+    a separate thread.
+
+    :param device: the BlueZDevice object that is this wacom device
+    '''
+
+    __gsignals__ = {
+        'drawing':
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+        'done':
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT, )),
+        'button-press-required':
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
+        # battery level in %, boolean for is-charging
+        "battery-status":
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_INT, GObject.TYPE_BOOLEAN)),
+    }
+
+    def __init__(self, device, config=None):
+        GObject.Object.__init__(self)
+        self._device = device
+        self.thread = None
+        self._is_running = False
+        self._config = None
+
+        try:
+            self._config = config.devices[device.address]
+        except KeyError:
+            self._uuid = None
+            self._wacom_protocol = None
+        else:
+            self._uuid = self._config['uuid']
+            self._init_protocol()
+
+    def _init_protocol(self):
+        self._wacom_protocol = WacomProtocol(self._device, self._uuid)
+        self._wacom_protocol.connect('drawing', self._on_drawing_received)
+        self._wacom_protocol.connect('button-press-required', self._on_button_press_required)
+        self._wacom_protocol.connect('battery-status', self._on_battery_status)
+
+    def _on_drawing_received(self, protocol, drawing):
+        self.emit('drawing', drawing)
+
+    def _on_button_press_required(self, protocol):
+        self.emit('button-press-required')
+
+    def _on_battery_status(self, protocol, percent, is_charging):
+        self.emit('battery-status', percent, is_charging)
+
+    @GObject.Property
+    def uuid(self):
+        assert self._uuid is not None
+        return self._uuid
+
+    @GObject.Property
+    def protocol(self):
+        assert self._wacom_protocol is not None
+        if self._wacom_protocol.is_spark():
+            return TuhiConfig.Protocol.SPARK
+        return TuhiConfig.Protocol.SLATE
+
     def register_device(self):
         self._uuid = uuid.uuid4().hex[:12]
-        logger.debug(f'{self.device.address}: registering device, assigned {self.uuid}')
-        if self.is_spark():
-            self.register_device_spark()
+        logger.debug(f'{self._device.address}: registering device, assigned {self.uuid}')
+        self._init_protocol()
+        if self._wacom_protocol.is_spark():
+            self._wacom_protocol.register_device_spark()
         else:
-            self.register_device_slate()
+            self._wacom_protocol.register_device_slate()
         logger.info('registration completed')
         self.notify('uuid')
 
     def run(self):
         if self._is_running:
-            logger.error(f'{self.device.address}: already synching, ignoring this request')
+            logger.error(f'{self._device.address}: already synching, ignoring this request')
             return
 
-        logger.debug(f'{self.device.address}: starting')
+        logger.debug(f'{self._device.address}: starting')
         self._is_running = True
         exception = None
         try:
             if self._register_mode:
                 self.register_device()
             else:
-                self.retrieve_data()
+                assert self._wacom_protocol is not None
+                self._wacom_protocol.retrieve_data()
         except WacomException as e:
             logger.error(f'**** Exception: {e} ****')
             exception = e

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -296,10 +296,10 @@ class WacomProtocol(GObject.Object):
         fw = ''.join([hex(d)[2:] for d in data[1:]])
         return fw.upper()
 
-    def bb_command(self):
+    def get_name(self):
         data = self.send_nordic_command_sync(command=0xbb,
                                              expected_opcode=0xbc)
-        logger.debug(f'bb returned {data}')
+        return bytes(data)
 
     def get_dimensions(self, arg):
         possible_args = {
@@ -539,7 +539,8 @@ class WacomProtocol(GObject.Object):
         self.set_time()
         self.read_time()
         self.ec_command()
-        self.bb_command()
+        name = self.get_name()
+        logger.info(f'device name is {name}')
         w = self.get_dimensions('width')
         h = self.get_dimensions('height')
         if self.width != w or self.height != h:
@@ -649,7 +650,8 @@ class WacomProtocolSpark(WacomProtocol):
                                       expected_opcode=0xb3)
         self.set_time()
         self.read_time()
-        self.bb_command()
+        name = self.get_name()
+        logger.info(f'device name is {name}')
         fw_high = self.get_firmware_version(0)
         fw_low = self.get_firmware_version(1)
         logger.info(f'firmware is {fw_high}-{fw_low}')


### PR DESCRIPTION
Based on #56, there might be some differences between the Intuos Pro Paper and the Slate.
Instead of having a bunch of ifs, use the power of subclassing to make the code cleaner.

We add a new config option `Protocol` so we can store it and reuse it on later reloads of the daemon.

The idea is to detect the protocol only during the register step, and then rely on the config file forever for this device.

Bonus: we managed to decipher `0xbb` command :)

@whot, feel free to merge it or fix it for your spark, and reuse as a base for the Intuos Pro.