### PR TITLE
Split out the different protocols in subclasses -- v3

### DIFF
--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -134,7 +134,7 @@ class TuhiDevice(GObject.Object):
     def _on_bluez_device_connected(self, bluez_device):
         logger.debug(f'{bluez_device.address}: connected')
         if self._wacom_device is None:
-            self._wacom_device = WacomDevice(bluez_device, self._uuid)
+            self._wacom_device = WacomDevice(bluez_device, self.config)
             self._wacom_device.connect('drawing', self._on_drawing_received)
             self._wacom_device.connect('done', self._on_fetching_finished, bluez_device)
             self._wacom_device.connect('button-press-required', self._on_button_press_required)

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -27,7 +27,7 @@ logging.basicConfig(format='%(levelname)s: %(name)s: %(message)s',
                     level=logging.INFO)
 logger = logging.getLogger('tuhi')
 
-WACOM_COMPANY_ID = 0x4755
+WACOM_COMPANY_IDS = [0x4755]
 
 
 class TuhiDevice(GObject.Object):
@@ -244,10 +244,10 @@ class Tuhi(GObject.Object):
 
     @classmethod
     def _device_in_register_mode(cls, bluez_device):
-        if bluez_device.vendor_id != WACOM_COMPANY_ID:
+        if bluez_device.vendor_id not in WACOM_COMPANY_IDS:
             return False
 
-        manufacturer_data = bluez_device.get_manufacturer_data(WACOM_COMPANY_ID)
+        manufacturer_data = bluez_device.get_manufacturer_data(bluez_device.vendor_id)
         return manufacturer_data is not None and len(manufacturer_data) == 4
 
     def _on_bluez_discovery_started(self, manager):
@@ -273,7 +273,7 @@ class Tuhi(GObject.Object):
         except KeyError:
             pass
 
-        if uuid is None and bluez_device.vendor_id != WACOM_COMPANY_ID:
+        if uuid is None and bluez_device.vendor_id not in WACOM_COMPANY_IDS:
             return
 
         # if event is set, the device has been 'hotplugged' in the bluez stack

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -21,7 +21,6 @@ from gi.repository import GObject, GLib
 from tuhi.dbusserver import TuhiDBusServer
 from tuhi.ble import BlueZDeviceManager
 from tuhi.wacom import WacomDevice
-from tuhi.wacom import Protocol
 from tuhi.config import TuhiConfig
 
 logging.basicConfig(format='%(levelname)s: %(name)s: %(message)s',
@@ -59,7 +58,6 @@ class TuhiDevice(GObject.Object):
         # We need either uuid or registered as false
         assert uuid is not None or registered is False
         self.registered = registered
-        self._uuid = uuid
         self._battery_state = TuhiDevice.BatteryState.UNKNOWN
         self._battery_percent = 0
         self._last_battery_update_time = 0
@@ -168,10 +166,7 @@ class TuhiDevice(GObject.Object):
         self._tuhi_dbus_device.notify_button_press_required()
 
     def _on_uuid_updated(self, wacom_device, pspec, bluez_device):
-        protocol = Protocol.SLATE
-        if wacom_device.is_spark():
-            protocol = Protocol.SPARK
-        self.config.new_device(bluez_device.address, wacom_device.uuid, protocol)
+        self.config.new_device(bluez_device.address, wacom_device.uuid, wacom_device.protocol)
         self.registered = True
 
     def _on_listening_updated(self, dbus_device, pspec):

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -21,6 +21,7 @@ from gi.repository import GObject, GLib
 from tuhi.dbusserver import TuhiDBusServer
 from tuhi.ble import BlueZDeviceManager
 from tuhi.wacom import WacomDevice
+from tuhi.wacom import Protocol
 from tuhi.config import TuhiConfig
 
 logging.basicConfig(format='%(levelname)s: %(name)s: %(message)s',
@@ -167,7 +168,10 @@ class TuhiDevice(GObject.Object):
         self._tuhi_dbus_device.notify_button_press_required()
 
     def _on_uuid_updated(self, wacom_device, pspec, bluez_device):
-        self.config.new_device(bluez_device.address, wacom_device.uuid)
+        protocol = Protocol.SLATE
+        if wacom_device.is_spark():
+            protocol = Protocol.SPARK
+        self.config.new_device(bluez_device.address, wacom_device.uuid, protocol)
         self.registered = True
 
     def _on_listening_updated(self, dbus_device, pspec):
@@ -287,7 +291,7 @@ class Tuhi(GObject.Object):
             if uuid is None:
                 logger.info(f'{bluez_device.address}: device without config, must be registered first')
                 return
-            logger.debug(f'{bluez_device.address}: UUID {uuid}')
+            logger.debug(f'{bluez_device.address}: UUID {uuid} protocol: {config["Protocol"]}')
 
         # create the device if unknown from us
         if bluez_device.address not in self.devices:

--- a/tuhi/config.py
+++ b/tuhi/config.py
@@ -19,6 +19,7 @@ import configparser
 import re
 import logging
 from .drawing import Drawing
+from .wacom import Protocol
 
 logger = logging.getLogger('tuhi.config')
 
@@ -67,11 +68,14 @@ class TuhiConfig(GObject.Object):
                 self._purge_drawings(entry)
 
                 assert config['Device']['Address'] == entry.name
+                if 'Protocol' not in config['Device']:
+                    config['Device']['Protocol'] = Protocol.UNKNOWN.value
                 self._devices[entry.name] = config['Device']
 
-    def new_device(self, address, uuid):
+    def new_device(self, address, uuid, protocol):
         assert is_btaddr(address)
         assert len(uuid) == 12
+        assert protocol != Protocol.UNKNOWN
 
         logger.debug(f'{address}: adding new config, UUID {uuid}')
         path = os.path.join(ROOT_PATH, address)
@@ -92,6 +96,7 @@ class TuhiConfig(GObject.Object):
         config['Device'] = {
             'Address': address,
             'UUID': uuid,
+            'Protocol': protocol.value,
         }
 
         with open(path, 'w') as configfile:

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -516,10 +516,7 @@ class WacomProtocol(GObject.Object):
         self.register_connection()
         logger.info('Press the button now to confirm')
         self.emit('button-press-required')
-        data = self.wait_nordic_data([0xe4, 0xb3], 10)
-        if data.opcode == 0xb3:
-            # generic ACK
-            self.check_ack(data)
+        self.wait_nordic_data(0xe4, 10)
         self.set_time()
         self.read_time()
         self.ec_command()

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -262,8 +262,8 @@ class WacomDevice(GObject.Object):
 
     def set_time(self):
         # Device time is UTC
-        self.current_time = time.strftime('%y%m%d%H%M%S', time.gmtime())
-        args = [int(i) for i in binascii.unhexlify(self.current_time)]
+        current_time = time.strftime('%y%m%d%H%M%S', time.gmtime())
+        args = [int(i) for i in binascii.unhexlify(current_time)]
         self.send_nordic_command_sync(command=0xb6,
                                       expected_opcode=0xb3,
                                       arguments=args)

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -14,6 +14,7 @@
 
 import binascii
 import calendar
+import enum
 import logging
 import threading
 import time
@@ -40,6 +41,14 @@ MYSTERIOUS_NOTIFICATION_CHRC_UUID = '3a340721-c572-11e5-86c5-0002a5d5c51b'
 
 WACOM_SLATE_WIDTH = 21600
 WACOM_SLATE_HEIGHT = 14800
+
+
+@enum.unique
+class Protocol(enum.Enum):
+    UNKNOWN = 'unknown'
+    SPARK = 'spark'
+    SLATE = 'slate'
+    INTUOS_PRO = 'intuos-pro'
 
 
 def signed_char_to_int(v):

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -39,9 +39,6 @@ WACOM_OFFLINE_CHRC_PEN_DATA_UUID = 'ffee0003-bbaa-9988-7766-554433221100'
 MYSTERIOUS_NOTIFICATION_SERVICE_UUID = '3a340720-c572-11e5-86c5-0002a5d5c51b'
 MYSTERIOUS_NOTIFICATION_CHRC_UUID = '3a340721-c572-11e5-86c5-0002a5d5c51b'
 
-WACOM_SLATE_WIDTH = 21600
-WACOM_SLATE_HEIGHT = 14800
-
 
 @enum.unique
 class Protocol(enum.Enum):
@@ -102,8 +99,11 @@ class WacomProtocol(GObject.Object):
     '''
     Internal class to handle the communication with the Wacom device.
 
+
     :param device: the BlueZDevice object that is this wacom device
+    :param uuid: the UUID {to be} assigned to the device
     '''
+    protocol = Protocol.UNKNOWN
 
     __gsignals__ = {
         'drawing':
@@ -120,8 +120,6 @@ class WacomProtocol(GObject.Object):
         self.device = device
         self.nordic_answer = None
         self.pen_data_buffer = []
-        self.width = WACOM_SLATE_WIDTH
-        self.height = WACOM_SLATE_HEIGHT
         self.name = device.name
         self._uuid = uuid
         self.fw_logger = logging.getLogger('tuhi.fw')
@@ -135,8 +133,9 @@ class WacomProtocol(GObject.Object):
         device.connect_gatt_value(MYSTERIOUS_NOTIFICATION_CHRC_UUID,
                                   self._on_mysterious_data_received)
 
-    def is_spark(self):
-        return MYSTERIOUS_NOTIFICATION_CHRC_UUID not in self.device.characteristics
+    @classmethod
+    def is_spark(cls, device):
+        return MYSTERIOUS_NOTIFICATION_CHRC_UUID not in device.characteristics
 
     def _on_mysterious_data_received(self, name, value):
         self.fw_logger.debug(f'mysterious: {binascii.hexlify(bytes(value))}')
@@ -329,15 +328,11 @@ class WacomProtocol(GObject.Object):
     def is_data_available(self):
         data = self.send_nordic_command_sync(command=0xc1,
                                              expected_opcode=0xc2)
-        n = 0
-        if self.is_spark():
-            n = int.from_bytes(data[0:2], byteorder='big')
-        else:
-            n = int.from_bytes(data[0:2], byteorder='little')
+        n = int.from_bytes(data[0:2], byteorder='little')
         logger.debug(f'Drawings available: {n}')
         return n > 0
 
-    def get_stroke_data_slate(self):
+    def get_stroke_data(self):
         data = self.send_nordic_command_sync(command=0xcc,
                                              expected_opcode=0xcf)
         # logger.debug(f'cc returned {data} ')
@@ -345,26 +340,6 @@ class WacomProtocol(GObject.Object):
         str_timestamp = ''.join([f'{d:02x}' for d in data[4:]])
         timestamp = time.strptime(str_timestamp, '%y%m%d%H%M%S')
         return count, timestamp
-
-    def get_stroke_data_spark(self):
-        data = self.send_nordic_command_sync(command=0xc5,
-                                             expected_opcode=[0xc7, 0xcd])
-        # FIXME: Sometimes the 0xc7 is missing on the spark? Not in any of
-        # the btsnoop logs but I only rarely get a c7 response here
-        count = 0
-        if data.opcode == 0xc7:
-            count = int.from_bytes(data[0:4], byteorder='little')
-            data = self.wait_nordic_data(0xcd, 5)
-            # logger.debug(f'cc returned {data} ')
-
-        str_timestamp = ''.join([f'{d:02x}' for d in data])
-        timestamp = time.strptime(str_timestamp, '%y%m%d%H%M%S')
-        return count, timestamp
-
-    def get_stroke_data(self):
-        if not self.is_spark():
-            return self.get_stroke_data_slate()
-        return self.get_stroke_data_spark()
 
     def start_reading(self):
         data = self.send_nordic_command_sync(command=0xc3,
@@ -377,27 +352,17 @@ class WacomProtocol(GObject.Object):
         if data[0] != 0xed:
             raise WacomException(f'unexpected answer: {data[0]:02x}')
         crc = data[1:]
-        if self.is_spark():
-            data = self.wait_nordic_data(0xc9, 5)
-            crc = data
         crc.reverse()
         crc = int(binascii.hexlify(bytes(crc)), 16)
         pen_data = self.pen_data_buffer
         self.pen_data_buffer = []
         if crc != binascii.crc32(bytes(pen_data)):
-            if not self.is_spark():
-                raise WacomCorruptDataException("CRCs don't match")
-            else:
-                logger.error("CRCs don't match")
+            raise WacomCorruptDataException("CRCs don't match")
         return pen_data
 
     def ack_transaction(self):
-        if self.is_spark():
-            opcode = None
-        else:
-            opcode = 0xb3
         self.send_nordic_command_sync(command=0xca,
-                                      expected_opcode=opcode)
+                                      expected_opcode=0xb3)
 
     def next_pen_data(self, data, offset):
         debug_data = []
@@ -527,8 +492,6 @@ class WacomProtocol(GObject.Object):
     def retrieve_data(self):
         try:
             self.check_connection()
-            if self.is_spark():
-                self.e3_command()
             self.set_time()
             battery, charging = self.get_battery_info()
             if charging:
@@ -536,21 +499,20 @@ class WacomProtocol(GObject.Object):
             else:
                 logger.debug(f'device is discharging: {battery}%')
             self.emit('battery-status', battery, charging)
-            if not self.is_spark():
-                self.width = w = self.get_dimensions('width')
-                self.height = h = self.get_dimensions('height')
-                logger.debug(f'dimensions: {w}x{h}')
+            self.width = w = self.get_dimensions('width')
+            self.height = h = self.get_dimensions('height')
+            logger.debug(f'dimensions: {w}x{h}')
 
-                fw_high = self.get_firmware_version(0)
-                fw_low = self.get_firmware_version(1)
-                logger.debug(f'firmware is {fw_high}-{fw_low}')
-                self.ec_command()
+            fw_high = self.get_firmware_version(0)
+            fw_low = self.get_firmware_version(1)
+            logger.debug(f'firmware is {fw_high}-{fw_low}')
+            self.ec_command()
             if self.read_offline_data() == 0:
                 logger.info('no data to retrieve')
         except WacomEEAGAINException:
             logger.warning('no data, please make sure the LED is blue and the button is pressed to switch it back to green')
 
-    def register_device_slate(self):
+    def register_device(self):
         self.register_connection()
         logger.info('Press the button now to confirm')
         self.emit('button-press-required')
@@ -571,7 +533,88 @@ class WacomProtocol(GObject.Object):
         fw_low = self.get_firmware_version(1)
         logger.info(f'firmware is {fw_high}-{fw_low}')
 
-    def register_device_spark(self):
+
+class WacomProtocolSlate(WacomProtocol):
+    '''
+    Subclass to handle the communication oddities with the Wacom Slate-like
+    devices.
+
+    :param device: the BlueZDevice object that is this wacom device
+    '''
+    width = 21600
+    height = 14800
+    protocol = Protocol.SLATE
+
+
+class WacomProtocolSpark(WacomProtocol):
+    '''
+    Subclass to handle the communication oddities with the Wacom Spark-like
+    devices.
+
+    :param device: the BlueZDevice object that is this wacom device
+    '''
+    width = 21600
+    height = 14800
+    protocol = Protocol.SPARK
+
+    def is_data_available(self):
+        data = self.send_nordic_command_sync(command=0xc1,
+                                             expected_opcode=0xc2)
+        n = int.from_bytes(data[0:2], byteorder='big')
+        logger.debug(f'Drawings available: {n}')
+        return n > 0
+
+    def get_stroke_data(self):
+        data = self.send_nordic_command_sync(command=0xc5,
+                                             expected_opcode=[0xc7, 0xcd])
+        # FIXME: Sometimes the 0xc7 is missing on the spark? Not in any of
+        # the btsnoop logs but I only rarely get a c7 response here
+        count = 0
+        if data.opcode == 0xc7:
+            count = int.from_bytes(data[0:4], byteorder='little')
+            data = self.wait_nordic_data(0xcd, 5)
+            # logger.debug(f'cc returned {data} ')
+
+        str_timestamp = ''.join([f'{d:02x}' for d in data])
+        timestamp = time.strptime(str_timestamp, '%y%m%d%H%M%S')
+        return count, timestamp
+
+    def wait_for_end_read(self):
+        data = self.wait_nordic_data(0xc8, 5)
+        if data[0] != 0xed:
+            raise WacomException(f'unexpected answer: {data[0]:02x}')
+        crc = data[1:]
+        data = self.wait_nordic_data(0xc9, 5)
+        crc = data
+        crc.reverse()
+        crc = int(binascii.hexlify(bytes(crc)), 16)
+        pen_data = self.pen_data_buffer
+        self.pen_data_buffer = []
+        if crc != binascii.crc32(bytes(pen_data)):
+            logger.error("CRCs don't match")
+        return pen_data
+
+    def ack_transaction(self):
+        self.send_nordic_command_sync(command=0xca,
+                                      expected_opcode=None)
+
+    def retrieve_data(self):
+        try:
+            self.check_connection()
+            self.e3_command()
+            self.set_time()
+            battery, charging = self.get_battery_info()
+            if charging:
+                logger.debug(f'device is plugged in and charged at {battery}%')
+            else:
+                logger.debug(f'device is discharging: {battery}%')
+            self.emit('battery-status', battery, charging)
+            if self.read_offline_data() == 0:
+                logger.info('no data to retrieve')
+        except WacomEEAGAINException:
+            logger.warning('no data, please make sure the LED is blue and the button is pressed to switch it back to green')
+
+    def register_device(self):
         try:
             self.check_connection()
         except WacomWrongModeException:
@@ -630,19 +673,40 @@ class WacomDevice(GObject.Object):
         except KeyError:
             # unregistered device
             self._uuid = None
-            self._protocol = None
             self._wacom_protocol = None
         else:
             self._uuid = self._config['uuid']
-            try:
-                self._protocol = next(p for p in Protocol if p.value == self._config['Protocol'])
-            except StopIteration:
-                logger.error(f'Unknown protocol in configuration: {self._config["Protocol"]}')
-                raise WacomCorruptDataException(f'Unknown Protocol {self._config["Protocol"]}')
             self._init_protocol()
 
     def _init_protocol(self):
-        self._wacom_protocol = WacomProtocol(self._device, self._uuid)
+        protocol = Protocol.UNKNOWN
+        if self._config is not None:
+            try:
+                protocol = next(p for p in Protocol if p.value == self._config['Protocol'])
+            except StopIteration:
+                logger.error(f'Unknown protocol in configuration: {self._config["Protocol"]}')
+                raise WacomCorruptDataException(f'Unknown Protocol {self._config["Protocol"]}')
+
+        if protocol == Protocol.UNKNOWN:
+            # we are registering a new device, or we might have an early
+            # config file from an older tuhi version
+            if WacomProtocol.is_spark(self._device):
+                protocol = Protocol.SPARK
+            else:
+                protocol = Protocol.SLATE
+
+        if protocol == Protocol.SPARK:
+            self._wacom_protocol = WacomProtocolSpark(self._device, self._uuid)
+        elif protocol == Protocol.SLATE:
+            self._wacom_protocol = WacomProtocolSlate(self._device, self._uuid)
+        else:
+            # FIXME: change to an assert once intuos-pro is implemented, we
+            # never get here
+            logger.error(f'Unknown Protocol {protocol}')
+            raise WacomCorruptDataException(f'Protocol "{protocol}" not implemented')
+
+        logger.debug(f'{self._device.name} is using {type(self._wacom_protocol)}')
+
         self._wacom_protocol.connect('drawing', self._on_drawing_received)
         self._wacom_protocol.connect('button-press-required', self._on_button_press_required)
         self._wacom_protocol.connect('battery-status', self._on_battery_status)
@@ -663,19 +727,14 @@ class WacomDevice(GObject.Object):
 
     @GObject.Property
     def protocol(self):
-        assert self._protocol is not None
-        return self._protocol
+        assert self._wacom_protocol is not None
+        return self._wacom_protocol.protocol
 
     def register_device(self):
         self._uuid = uuid.uuid4().hex[:12]
         logger.debug(f'{self._device.address}: registering device, assigned {self.uuid}')
         self._init_protocol()
-        if self._wacom_protocol.is_spark():
-            self._wacom_protocol.register_device_spark()
-            self._protocol = Protocol.SPARK
-        else:
-            self._wacom_protocol.register_device_slate()
-            self._protocol = Protocol.SLATE
+        self._wacom_protocol.register_device()
         logger.info('registration completed')
         self.notify('uuid')
 

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -286,10 +286,10 @@ class WacomDevice(GObject.Object):
         fw = ''.join([hex(d)[2:] for d in data[1:]])
         return fw.upper()
 
-    def bb_command(self):
+    def get_name(self):
         data = self.send_nordic_command_sync(command=0xbb,
                                              expected_opcode=0xbc)
-        logger.debug(f'bb returned {data}')
+        return bytes(data)
 
     def get_dimensions(self, arg):
         possible_args = {
@@ -562,7 +562,8 @@ class WacomDevice(GObject.Object):
         self.set_time()
         self.read_time()
         self.ec_command()
-        self.bb_command()
+        name = self.get_name()
+        logger.info(f'device name is {name}')
         w = self.get_dimensions('width')
         h = self.get_dimensions('height')
         if self.width != w or self.height != h:
@@ -591,7 +592,8 @@ class WacomDevice(GObject.Object):
                                       expected_opcode=0xb3)
         self.set_time()
         self.read_time()
-        self.bb_command()
+        name = self.get_name()
+        logger.info(f'device name is {name}')
         fw_high = self.get_firmware_version(0)
         fw_low = self.get_firmware_version(1)
         logger.info(f'firmware is {fw_high}-{fw_low}')

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -41,11 +41,6 @@ MYSTERIOUS_NOTIFICATION_CHRC_UUID = '3a340721-c572-11e5-86c5-0002a5d5c51b'
 WACOM_SLATE_WIDTH = 21600
 WACOM_SLATE_HEIGHT = 14800
 
-ORIENTATION_PORTRAIT = 'portrait'
-ORIENTATION_UPSIDEDOWN_PORTRAIT = 'tiartrop'
-ORIENTATION_LANDSCAPE = 'landscape'
-ORIENTATION_UPSIDEDOWN_LANDSCAPE = 'epacsdnal'
-
 
 def signed_char_to_int(v):
     return int.from_bytes([v], byteorder='little', signed=True)
@@ -119,7 +114,6 @@ class WacomDevice(GObject.Object):
         self.device = device
         self.nordic_answer = None
         self.pen_data_buffer = []
-        self.orientation = ORIENTATION_PORTRAIT
         self.thread = None
         self.width = WACOM_SLATE_WIDTH
         self.height = WACOM_SLATE_HEIGHT
@@ -174,19 +168,6 @@ class WacomDevice(GObject.Object):
                     x = int.from_bytes(data[0:2], byteorder='little')
                     y = int.from_bytes(data[2:4], byteorder='little')
                     pressure = int.from_bytes(data[4:6], byteorder='little')
-                    if self.orientation == ORIENTATION_PORTRAIT:
-                        t = x
-                        x = self.height - y
-                        y = t
-                    elif self.orientation == ORIENTATION_UPSIDEDOWN_PORTRAIT:
-                        t = x
-                        x = y
-                        y = self.width - t
-                    elif self.orientation == ORIENTATION_LANDSCAPE:
-                        pass
-                    elif self.orientation == ORIENTATION_UPSIDEDOWN_LANDSCAPE:
-                        x = self.width - x
-                        y = self.height - y
                     self.logger.info(f'New Pen Data: ({x},{y}), pressure: {pressure}')
                 data = data[6:]
 
@@ -559,10 +540,6 @@ class WacomDevice(GObject.Object):
             if not self.is_spark():
                 self.width = w = self.get_dimensions('width')
                 self.height = h = self.get_dimensions('height')
-                if self.orientation in [ORIENTATION_PORTRAIT,
-                                        ORIENTATION_UPSIDEDOWN_PORTRAIT]:
-                    w = self.height
-                    h = self.width
                 logger.debug(f'dimensions: {w}x{h}')
 
                 fw_high = self.get_firmware_version(0)


### PR DESCRIPTION
From PR #76:

> From PR #74:
> >
> > Based on #56, there might be some differences between the Intuos Pro Paper and the Slate.
> > Instead of having a bunch of ifs, use the power of subclassing to make the code cleaner.
> > 
> > We add a new config option Protocol so we can store it and reuse it on later reloads of the daemon.
> > 
> > The idea is to detect the protocol only during the register step, and then rely on the config file forever for this device.
> > 
> > Bonus: we managed to decipher 0xbb command :)
> > 
> 
> Supersedes #74, with a few changes and fixes, seems to work on my Spark now

Supersedes #76. Squashed up the commits to make the story more linear, fixed up the protocol instantiation, and re-order the hierarchy of classes (old -> new instead of new -> old)