### PR TITLE
Listen/Register handling cleanup

### DIFF
--- a/tools/tuhi-kete.py
+++ b/tools/tuhi-kete.py
@@ -402,6 +402,8 @@ class Searcher(Worker):
     def _on_notify_search(self, manager, pspec):
         if not manager.searching:
             logger.info('Search cancelled')
+        else:
+            self.stop()
 
     def _on_unregistered_device(self, manager, device):
         logger.info(f'Unregistered device: {device}')
@@ -454,6 +456,7 @@ class Listener(Worker):
             return
 
         logger.info(f'{device}: Listening stopped')
+        self.stop()
 
     def _on_drawings_available(self, device, pspec):
         self._log_drawings_available(device)

--- a/tools/tuhi-kete.py
+++ b/tools/tuhi-kete.py
@@ -341,15 +341,24 @@ class TuhiKeteManager(_DBusObject):
                     pass
             self.notify('devices')
 
+    def _handle_unregistered_device(self, objpath):
+        for addr, dev in self._devices.items():
+            if dev.objpath == objpath:
+                self.emit('unregistered-device', dev)
+                return
+
+        device = TuhiKeteDevice(self, objpath)
+        self._unregistered_devices[objpath] = device
+
+        logger.debug(f'New unregistered device: {device}')
+        self.emit('unregistered-device', device)
+
     def _on_signal_received(self, proxy, sender, signal, parameters):
         if signal == 'SearchStopped':
             self.notify('searching')
         elif signal == 'UnregisteredDevice':
             objpath = parameters[0]
-            device = TuhiKeteDevice(self, objpath)
-            self._unregistered_devices[objpath] = device
-            logger.debug(f'Found unregistered device: {device}')
-            self.emit('unregistered-device', device)
+            self._handle_unregistered_device(objpath)
 
     def __getitem__(self, btaddr):
         return self._devices[btaddr]
@@ -387,9 +396,6 @@ class Searcher(Worker):
 
         self.manager.start_search()
         logger.debug('Started searching')
-
-        for d in self.manager.devices:
-            self._on_unregistered_device(self.manager, d)
 
     def stop(self):
         if self.manager.searching:

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -166,9 +166,6 @@ class TuhiDevice(GObject.Object):
             pass
 
     def _on_register_requested(self, dbus_device):
-        if self.registered:
-            return
-
         self.register()
 
     def _on_drawing_received(self, device, drawing):

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -139,7 +139,10 @@ class TuhiDevice(GObject.Object):
             self._wacom_device.connect('notify::uuid', self._on_uuid_updated, bluez_device)
             self._wacom_device.connect('battery-status', self._on_battery_status, bluez_device)
 
-        self._wacom_device.start(not self.registered)
+        if not self.registered:
+            self._wacom_device.start_register()
+        else:
+            self._wacom_device.start_listen()
 
     def _on_bluez_device_disconnected(self, bluez_device):
         logger.debug(f'{bluez_device.address}: disconnected')

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -291,7 +291,7 @@ class BlueZDeviceManager(GObject.Object):
     '''
     __gsignals__ = {
         'device-added':
-            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT, GObject.TYPE_BOOLEAN)),
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         'device-updated':
             (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         'discovery-started':
@@ -326,7 +326,7 @@ class BlueZDeviceManager(GObject.Object):
         # object path length and process them in order, this way we're
         # guaranteed that the objects we need already exist.
         for obj in self._om.get_objects():
-            self._process_object(obj, event=False)
+            self._process_object(obj)
 
     def _discovery_timeout_expired(self):
         self.stop_discovery()
@@ -428,7 +428,7 @@ class BlueZDeviceManager(GObject.Object):
         if obj.get_interface(ORG_BLUEZ_ADAPTER1) is not None:
             self._process_adapter(obj)
         elif obj.get_interface(ORG_BLUEZ_DEVICE1) is not None:
-            self._process_device(obj, event)
+            self._process_device(obj)
         elif obj.get_interface(ORG_BLUEZ_GATTCHARACTERISTIC1) is not None:
             return True
 
@@ -438,11 +438,11 @@ class BlueZDeviceManager(GObject.Object):
         objpath = obj.get_object_path()
         logger.debug(f'Adapter: {objpath}')
 
-    def _process_device(self, obj, event=True):
+    def _process_device(self, obj):
         dev = BlueZDevice(self._om, obj)
         self.devices.append(dev)
         dev.connect('updated', self._on_device_updated)
-        self.emit('device-added', dev, event)
+        self.emit('device-added', dev)
 
     def _process_characteristic(self, obj):
         objpath = obj.get_object_path()

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -523,6 +523,9 @@ class TuhiDBusServer(_TuhiDBus):
                                               for d in self._devices if d.registered])
         self.properties_changed({'Devices': objpaths})
 
+        if not device.registered and self._is_searching:
+            self._emit_unregistered_signal(device)
+
     def _emit_unregistered_signal(self, device):
         arg = GLib.Variant.new_object_path(device.objpath)
         self.signal('UnregisteredDevice', arg, dest=self._searching_client[0])

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -162,6 +162,8 @@ class WacomProtocolLowLevelComm(GObject.Object):
             raise WacomEEAGAINException(f'unexpected answer: {data[0]:02x}')
         if data[0] == 0x01:
             raise WacomWrongModeException(f'wrong device mode')
+        if data[0] == 0x05:
+            raise WacomCorruptDataException(f'invalid opcode')
 
     def send_nordic_command_sync(self,
                                  command,


### PR DESCRIPTION
A bunch of cleanup patches to make the behaviour of listen/register more predictable, especially immediately after registering a device.

Fixes #79  and #80 