### PR TITLE
wacom: add support for a set_name on the Spark

### DIFF
--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -580,6 +580,15 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
             transaction_count += 1
         return transaction_count
 
+    def set_name(self, name):
+        # On the Spark, the name needs a trailing linebreak, otherwise the
+        # firmware gets confused.
+        args = [ord(c) for c in name] + [0x0a]
+        data = self.send_nordic_command_sync(command=0xbb,
+                                             arguments=args,
+                                             expected_opcode=0xb3)
+        return bytes(data)
+
     def register_device_finish(self):
         self.send_nordic_command_sync(command=0xe5,
                                       arguments=None,


### PR DESCRIPTION
@bentiss, please give this a try on the slate. On the IntuosPro the trailing linebreak is not needed so the question is now whether the slate needs it.

Part of #82 

