### PR TITLE
base: if gi.repository fails to import, warn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(name='tuhi',
       install_requires=[
           'svgwrite',
           'xdg',
+          'pygobject',
       ]
       )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(name='tuhi',
       python_requires='>=3.6',
       install_requires=[
           'svgwrite',
-          'gi',
           'xdg',
       ]
       )

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -16,7 +16,16 @@ import enum
 import logging
 import sys
 import time
-from gi.repository import GObject, GLib
+try:
+    from gi.repository import GObject, GLib
+except Exception as e:
+    print(f'************ Importing gi.repository failed **********')
+    print(f'* This is an issue with the gi module, not with tuhi *')
+    print(f'******************************************************')
+    print(f'The full exception is below:')
+    print(f'')
+    raise e
+
 
 from tuhi.dbusserver import TuhiDBusServer
 from tuhi.ble import BlueZDeviceManager


### PR DESCRIPTION
We need python 3.6 but old Ubuntus only have 3.5. 3.6 can be installed (and
thus we get past the 3.6 sys.version check), but the gi.repository backports
are in various states of disarray (see #103 and #104).

And Python (and in particular gi) makes it hard for users to distinguish
between "the dependencies are a mess" and "this is a bug in tuhi".

So let's catch any error during gi.repository import and print a warning to
the user, in the hope of getting less bugs caused by Ubuntu frankenpythons.
Still won't fix issues like #104, but I'm not sure how to test for those
errors.

Related to #103