### PR TITLE
flatpak: use cached versions from pypi instead of git

### DIFF
--- a/org.freedesktop.tuhi.json
+++ b/org.freedesktop.tuhi.json
@@ -77,8 +77,9 @@
             "buildsystem": "simple",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "git://anongit.freedesktop.org/xdg/pyxdg"
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/47/6e/311d5f22e2b76381719b5d0c6e9dc39cd33999adae67db71d7279a6d70f4/pyxdg-0.26.tar.gz#md5=db1c2af8300ca64ce3955b3cf2490c92",
+                    "sha512": "f5306e6e15af07df2599017500fc8ad83e722e5d5c6e4fda014aab1d77df92a3c3199a5be7a889faaecab72861e9910be9d80142d29856eb7a11f6ab9a923bd2"
                 }
             ],
             "build-commands": [
@@ -106,8 +107,9 @@
             "buildsystem": "simple",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/mozman/svgwrite.git"
+                    "type": "archive",
+                    "url": "https://pypi.python.org/packages/a6/e1/8d592fc801e1dc2958fe0c84c733ed729d4020daa1826c58978f9d601bb4/svgwrite-1.1.12.zip#md5=05780a4a8ba33c16842faf37818d670e",
+                    "sha512": "cafce1a39c932149cd9d531c7304e8568fde9bc5abd09b548a778cc7f7f4d74327da03fb01279a3a19dd8396487c8fba974d50c6dd645be3942a4ba6d76646df"
                 }
             ],
             "build-commands": [


### PR DESCRIPTION
Each time we redo the flatpak, we pull the files from git, which is less than optimal.

Rely on the cache provided by pypi to have consistent files.

Not sure if this is allowed or reliable, so asking everyone if this is acceptable.