### PR TITLE
Link to Arch Linux package tuhi-git in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ by "hi $foo, I want to connect".
 The word "register" was chosen because "pairing" is already in use by
 Bluetooth.
 
+Packages
+--------
+
+Arch Linux: [tuhi-git](https://aur.archlinux.org/packages/tuhi-git/)
+
 Installation
 ------------
 


### PR DESCRIPTION
On Arch Linux there's a tuhi-git package available for install. I added a link to it in the README.