### PR TITLE
tuhi: always use verbose mode when starting from git

### DIFF
--- a/tuhi.py
+++ b/tuhi.py
@@ -12,6 +12,7 @@
 #
 
 import tuhi.base
+import sys
 
 if __name__ == "__main__":
-    tuhi.base.main()
+    tuhi.base.main(sys.argv + ['--verbose'])


### PR DESCRIPTION
When starting from within the git directory, always use verbose mode. Because
you're debugging it, otherwise you wouldn't start from git.