### PR TITLE
Fixes, glorious fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,15 @@ org.freedesktop.tuhi1.Device
 
       These errnos indicate a bug in the daemon, and the client should
       display a message to that effect.
+
+  Signal: SyncState(i)
+      An enum to represent the current synchronization state of the device.
+      When on (1), Tuhi is currently trying to download data from the
+      device. When off (0), Tuhi is not currently connecting to the device.
+
+      This signal should be used for UI feedback.
+
+      This signal is only send when the device is **not** in Live mode.
 ```
 
 JSON File Format

--- a/tools/kete.py
+++ b/tools/kete.py
@@ -285,6 +285,13 @@ class TuhiKeteDevice(_DBusObject):
             elif err < 0:
                 logger.error(f'{self}: an error occured: {os.strerror(-err)}')
             self.notify('listening')
+        elif signal == 'SyncState':
+            state = parameters[0]
+            if state:
+                logger.debug(f'{self}: Downloading from device')
+            else:
+                logger.debug(f'{self}: Download done')
+
 
     def _on_properties_changed(self, proxy, changed_props, invalidated_props):
         if changed_props is None:

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -146,6 +146,10 @@ class TuhiDevice(GObject.Object):
     def battery_state(self, value):
         self._battery_state = value
 
+    @GObject.Property
+    def sync_state(self):
+        return self._sync_state
+
     def _connect_device(self, mode):
         self._signals['connected'] = self._bluez_device.connect('connected', self._on_bluez_device_connected, mode)
         self._signals['disconnected'] = self._bluez_device.connect('disconnected', self._on_bluez_device_disconnected)
@@ -166,6 +170,7 @@ class TuhiDevice(GObject.Object):
             self._wacom_device.connect('button-press-required', self._on_button_press_required)
             self._wacom_device.connect('notify::uuid', self._on_uuid_updated, bluez_device)
             self._wacom_device.connect('battery-status', self._on_battery_status, bluez_device)
+            self._wacom_device.connect('notify::sync-state', self._on_sync_state)
 
         if mode == DeviceMode.REGISTER:
             self._wacom_device.start_register()
@@ -179,6 +184,10 @@ class TuhiDevice(GObject.Object):
             del self._signals['connected']
         except KeyError:
             pass
+
+    def _on_sync_state(self, device, pspec):
+        self._sync_state = device.sync_state
+        self.notify('sync-state')
 
     def _on_bluez_device_disconnected(self, bluez_device):
         logger.debug(f'{bluez_device.address}: disconnected')

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -80,6 +80,12 @@ class TuhiDevice(GObject.Object):
         self._tuhi_dbus_device = None
 
     @GObject.Property
+    def dimensions(self):
+        if self._wacom_device is None:
+            return 0, 0
+        return self._wacom_device.dimensions
+
+    @GObject.Property
     def mode(self):
         return self._mode
 
@@ -174,6 +180,7 @@ class TuhiDevice(GObject.Object):
             self._wacom_device.connect('notify::uuid', self._on_uuid_updated, bluez_device)
             self._wacom_device.connect('battery-status', self._on_battery_status, bluez_device)
             self._wacom_device.connect('notify::sync-state', self._on_sync_state)
+            self._wacom_device.connect('notify::dimensions', self._on_dimensions)
 
         if mode == DeviceMode.REGISTER:
             self._wacom_device.start_register()
@@ -187,6 +194,9 @@ class TuhiDevice(GObject.Object):
             self._signals['connected'] = None
         except KeyError:
             pass
+
+    def _on_dimensions(self, device, pspec):
+        self.notify('dimensions')
 
     def _on_sync_state(self, device, pspec):
         self._sync_state = device.sync_state

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -363,11 +363,11 @@ class Tuhi(GObject.Object):
 
         d = self.devices[bluez_device.address]
 
-        if mode == DeviceMode.REGISTER:
+        if d.mode == DeviceMode.LISTEN or d.listening:
+            d.listen()
+        else:
             d.mode = mode
             logger.debug(f'{bluez_device.objpath}: call Register() on device')
-        elif d.listening:
-            d.listen()
 
     def _on_bluez_device_updated(self, manager, bluez_device):
         self._add_device(manager, bluez_device, True)

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -72,7 +72,8 @@ class TuhiDevice(GObject.Object):
         self._battery_percent = 0
         self._last_battery_update_time = 0
         self._battery_timer_source = None
-        self._signals = {}
+        self._signals = {'connected': None,
+                         'disconnected': None}
 
         self._bluez_device = bluez_device
 
@@ -151,8 +152,10 @@ class TuhiDevice(GObject.Object):
         return self._sync_state
 
     def _connect_device(self, mode):
-        self._signals['connected'] = self._bluez_device.connect('connected', self._on_bluez_device_connected, mode)
-        self._signals['disconnected'] = self._bluez_device.connect('disconnected', self._on_bluez_device_disconnected)
+        if self._signals['connected'] is None:
+            self._signals['connected'] = self._bluez_device.connect('connected', self._on_bluez_device_connected, mode)
+        if self._signals['disconnected'] is None:
+            self._signals['disconnected'] = self._bluez_device.connect('disconnected', self._on_bluez_device_disconnected)
         self._bluez_device.connect_device()
 
     def register(self):
@@ -181,7 +184,7 @@ class TuhiDevice(GObject.Object):
 
         try:
             bluez_device.disconnect(self._signals['connected'])
-            del self._signals['connected']
+            self._signals['connected'] = None
         except KeyError:
             pass
 
@@ -193,7 +196,7 @@ class TuhiDevice(GObject.Object):
         logger.debug(f'{bluez_device.address}: disconnected')
         try:
             bluez_device.disconnect(self._signals['disconnected'])
-            del self._signals['disconnected']
+            self._signals['disconnected'] = None
         except KeyError:
             pass
 

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -106,6 +106,10 @@ INTROSPECTION_XML = '''
     <signal name='LiveStopped'>
        <arg name='status' type='i' />
     </signal>
+
+    <signal name='SyncState'>
+       <arg name='status' type='i' />
+    </signal>
   </interface>
 </node>
 '''
@@ -182,6 +186,7 @@ class TuhiDBusDevice(_TuhiDBus):
         device.connect('notify::battery-percent', self._on_battery_percent)
         device.connect('notify::battery-state', self._on_battery_state)
         device.connect('device-error', self._on_device_error)
+        device.connect('notify::sync-state', self._on_sync_state)
 
     @GObject.Property
     def listening(self):
@@ -329,6 +334,14 @@ class TuhiDBusDevice(_TuhiDBus):
         if self.listening:
             self._stop_listening(self.connection, self._listening_client[0],
                                  -exception.errno)
+
+    def _on_sync_state(self, device, pspec):
+        if self._listening_client is None:
+            return
+
+        dest = self._listening_client[0]
+        status = GLib.Variant.new_int32(device.sync_state)
+        self.signal('SyncState', status, dest=dest)
 
     def _start_listening(self, connection, sender):
         if self.listening:

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -171,7 +171,7 @@ class TuhiDBusDevice(_TuhiDBus):
 
         self.bluez_device_objpath = device.bluez_device.objpath
         self.name = device.name
-        self.width, self.height = 0, 0
+        self.width, self.height = device.dimensions
         self.drawings = {}
         self.registered = device.registered
         self._listening = False
@@ -187,6 +187,7 @@ class TuhiDBusDevice(_TuhiDBus):
         device.connect('notify::battery-state', self._on_battery_state)
         device.connect('device-error', self._on_device_error)
         device.connect('notify::sync-state', self._on_sync_state)
+        device.connect('notify::dimensions', self._on_dimensions)
 
     @GObject.Property
     def listening(self):
@@ -334,6 +335,12 @@ class TuhiDBusDevice(_TuhiDBus):
         if self.listening:
             self._stop_listening(self.connection, self._listening_client[0],
                                  -exception.errno)
+
+    def _on_dimensions(self, device, pspec):
+        self.width, self.height = device.dimensions
+        w = GLib.Variant.new_uint32(self.width)
+        h = GLib.Variant.new_uint32(self.height)
+        self.properties_changed({'Dimensions': GLib.Variant.new_tuple(w, h)})
 
     def _on_sync_state(self, device, pspec):
         if self._listening_client is None:

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -1171,7 +1171,7 @@ class WacomProtocolIntuosPro(WacomProtocolSlate):
     @classmethod
     def time_from_bytes(self, data):
         seconds = int.from_bytes(data[0:4], byteorder='little')
-        return time.localtime(seconds)
+        return time.gmtime(seconds)
 
     # set_time is identical to spark/slate except the timestamp format
 

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -857,10 +857,7 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
             self.e3_command()
             self.set_time()
             battery, charging = self.get_battery_info()
-            if charging:
-                logger.debug(f'device is plugged in and charged at {battery}%')
-            else:
-                logger.debug(f'device is discharging: {battery}%')
+            logger.debug(f'device battery: {battery}% ({"dis" if not charging else ""}charging)')
             self.emit('battery-status', battery, charging)
             if self.read_offline_data() == 0:
                 logger.info('no data to retrieve')
@@ -1099,10 +1096,7 @@ class WacomProtocolSlate(WacomProtocolSpark):
         fw_low = self.get_firmware_version(1)
         logger.info(f'firmware is {fw_high}-{fw_low}')
         battery, charging = self.get_battery_info()
-        if charging:
-            logger.debug(f'device is plugged in and charged at {battery}%')
-        else:
-            logger.debug(f'device is discharging: {battery}%')
+        logger.debug(f'device battery: {battery}% ({"dis" if not charging else ""}charging)')
         self.emit('battery-status', battery, charging)
 
     def retrieve_data(self):
@@ -1110,10 +1104,7 @@ class WacomProtocolSlate(WacomProtocolSpark):
             self.check_connection()
             self.set_time()
             battery, charging = self.get_battery_info()
-            if charging:
-                logger.debug(f'device is plugged in and charged at {battery}%')
-            else:
-                logger.debug(f'device is discharging: {battery}%')
+            logger.debug(f'device battery: {battery}% ({"dis" if not charging else ""}charging)')
             self.emit('battery-status', battery, charging)
             self.width = w = self.get_dimensions('width')
             self.height = h = self.get_dimensions('height')

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -374,7 +374,7 @@ class WacomProtocolLowLevelComm(GObject.Object):
 
     def send_nordic_command_sync(self,
                                  command,
-                                 expected_opcode,
+                                 expected_opcode=0xb3,
                                  arguments=None):
         if arguments is None:
             arguments = [0x00]
@@ -421,9 +421,7 @@ class WacomRegisterHelper(WacomProtocolLowLevelComm):
             # Usually that triggers a WacomWrongModeException but here it's
             # expected
             try:
-                self.send_nordic_command_sync(command=0xe6,
-                                              expected_opcode=0xb3,
-                                              arguments=args)
+                self.send_nordic_command_sync(command=0xe6, arguments=args)
             except WacomWrongModeException:
                 # this is expected
                 pass
@@ -554,13 +552,10 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
 
     def check_connection(self):
         args = [int(i) for i in binascii.unhexlify(self._uuid)]
-        self.send_nordic_command_sync(command=0xe6,
-                                      expected_opcode=0xb3,
-                                      arguments=args)
+        self.send_nordic_command_sync(command=0xe6, arguments=args)
 
     def e3_command(self):
-        self.send_nordic_command_sync(command=0xe3,
-                                      expected_opcode=0xb3)
+        self.send_nordic_command_sync(command=0xe3)
 
     def time_to_bytes(self):
         # Device time is UTC
@@ -575,9 +570,7 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
 
     def set_time(self):
         args = self.time_to_bytes()
-        self.send_nordic_command_sync(command=0xb6,
-                                      expected_opcode=0xb3,
-                                      arguments=args)
+        self.send_nordic_command_sync(command=0xb6, arguments=args)
 
     def read_time(self):
         data = self.send_nordic_command_sync(command=0xb6,
@@ -622,13 +615,10 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
 
     def ec_command(self):
         args = [0x06, 0x00, 0x00, 0x00, 0x00, 0x00]
-        self.send_nordic_command_sync(command=0xec,
-                                      expected_opcode=0xb3,
-                                      arguments=args)
+        self.send_nordic_command_sync(command=0xec, arguments=args)
 
     def start_live(self, fd):
-        self.send_nordic_command_sync(command=0xb1,
-                                      expected_opcode=0xb3)
+        self.send_nordic_command_sync(command=0xb1)
         logger.debug(f'Starting wacom live mode on fd: {fd}')
 
         rdesc = wacom_live_rdesc_template[:]
@@ -646,15 +636,11 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
 
     def stop_live(self):
         args = [0x02]
-        self.send_nordic_command_sync(command=0xb1,
-                                      expected_opcode=0xb3,
-                                      arguments=args)
+        self.send_nordic_command_sync(command=0xb1, arguments=args)
 
     def b1_command(self):
         args = [0x01]
-        self.send_nordic_command_sync(command=0xb1,
-                                      expected_opcode=0xb3,
-                                      arguments=args)
+        self.send_nordic_command_sync(command=0xb1, arguments=args)
 
     def is_data_available(self):
         data = self.send_nordic_command_sync(command=0xc1,
@@ -835,14 +821,12 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
         # firmware gets confused.
         args = [ord(c) for c in name] + [0x0a]
         data = self.send_nordic_command_sync(command=0xbb,
-                                             arguments=args,
-                                             expected_opcode=0xb3)
+                                             arguments=args)
         return bytes(data)
 
     def register_device_finish(self):
         self.send_nordic_command_sync(command=0xe5,
-                                      arguments=None,
-                                      expected_opcode=0xb3)
+                                      arguments=None)
         self.set_time()
         self.read_time()
         name = self.get_name()
@@ -925,8 +909,7 @@ class WacomProtocolSlate(WacomProtocolSpark):
         self.fw_logger.debug(f'mysterious: {binascii.hexlify(bytes(value))}')
 
     def ack_transaction(self):
-        self.send_nordic_command_sync(command=0xca,
-                                      expected_opcode=0xb3)
+        self.send_nordic_command_sync(command=0xca)
 
     def is_data_available(self):
         data = self.send_nordic_command_sync(command=0xc1,
@@ -1053,8 +1036,7 @@ class WacomProtocolIntuosPro(WacomProtocolSlate):
     def set_name(self, name):
         args = [ord(c) for c in name]
         data = self.send_nordic_command_sync(command=0xbb,
-                                             arguments=args,
-                                             expected_opcode=0xb3)
+                                             arguments=args)
         return bytes(data)
 
     def check_connection(self):

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -939,6 +939,12 @@ class WacomProtocolSlate(WacomProtocolSpark):
         fw_high = self.get_firmware_version(0)
         fw_low = self.get_firmware_version(1)
         logger.info(f'firmware is {fw_high}-{fw_low}')
+        battery, charging = self.get_battery_info()
+        if charging:
+            logger.debug(f'device is plugged in and charged at {battery}%')
+        else:
+            logger.debug(f'device is discharging: {battery}%')
+        self.emit('battery-status', battery, charging)
 
     def retrieve_data(self):
         try:

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -1289,15 +1289,17 @@ class WacomDevice(GObject.Object):
             self._init_protocol(protocol)
 
     def _init_protocol(self, protocol):
-        if protocol == Protocol.SPARK:
-            self._wacom_protocol = WacomProtocolSpark(self._device, self._uuid)
-        elif protocol == Protocol.SLATE:
-            self._wacom_protocol = WacomProtocolSlate(self._device, self._uuid)
-        elif protocol == Protocol.INTUOS_PRO:
-            self._wacom_protocol = WacomProtocolIntuosPro(self._device, self._uuid)
-        else:
+        protocols = {
+                Protocol.SPARK: WacomProtocolSpark,
+                Protocol.SLATE: WacomProtocolSlate,
+                Protocol.INTUOS_PRO: WacomProtocolIntuosPro,
+        }
+
+        if protocol not in protocols:
             raise WacomCorruptDataException(f'Protocol "{protocol}" not implemented')
 
+        pclass = protocols[protocol]
+        self._wacom_protocol = pclass(self._device, self._uuid)
         logger.debug(f'{self._device.name} is using protocol {protocol}')
 
         self._wacom_protocol.connect(

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -496,7 +496,7 @@ class WacomProtocolLowLevelComm(GObject.Object):
 
         data = self.check_nordic_incoming()
 
-        logger.debug(f'received {data.opcode:02x} / {data.length:02x} / {b2hex(bytes(data))}')
+        # logger.debug(f'received {data.opcode:02x} / {data.length:02x} / {b2hex(bytes(data))}')
 
         if isinstance(expected_opcode, list):
             if data.opcode not in expected_opcode:
@@ -1084,6 +1084,7 @@ class WacomProtocolSlate(WacomProtocolSpark):
         logger.info(f'device name is {name}')
         w = self.get_dimensions('width')
         h = self.get_dimensions('height')
+        logger.debug(f'dimensions: {w}x{h}')
         if self.width != w or self.height != h:
             logger.error(f'incompatible dimensions: {w}x{h}')
         fw_high = self.get_firmware_version(0)


### PR DESCRIPTION
A set of miscellaneous fixes. Noteworthy:
- new `SyncState` signal so a GUI can show a spinner whenever we're talking to the device
- device dimensions are now set in the dbus interface
- [edit] a new FW logger interface that writes the data to `$HOME/.local/share/tuhi/log-<timestamp>.yaml`