### PR TITLE
wacom: normalize the pressure to the advertised [0, 0xffff] range

### DIFF
--- a/tools/kete.py
+++ b/tools/kete.py
@@ -629,7 +629,8 @@ class Fetcher(Worker):
                 elif self.orientation == 'Reverse-Landscape':
                     x, y = width - x, height - y
 
-                delta = (p['pressure'] - 1000.0) / 1000.0
+                # Pressure normalized range is [0, 0xffff]
+                delta = (p['pressure'] - 0x8000) / 0x8000
                 stroke_width = 0.4 + 0.20 * delta
                 points_with_sk_width.append((x, y, stroke_width))
 

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -963,7 +963,11 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
             if packet.bitmask & 0b00111100 == 0:
                 continue
 
-            stroke.new_abs((x, y), p)
+            def normalize(p):
+                NORMALIZED_RANGE = 0x10000
+                return NORMALIZED_RANGE * p / self.pressure
+
+            stroke.new_abs((x, y), normalize(p))
 
         drawing.seal()
         return drawing


### PR DESCRIPTION
This requires adjusting the svg conversion in kete as well, afaict the 1000
range there was chosen because it's (almost) the midpoint of the Bamboo series
with 2048 pressure grades. So let's use half of 0x10000 instead, which is
approximately 0x8000 as the crow flies.

Fixes #142