### PR TITLE
base: fix failing registration of new devices

### DIFF
--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -370,7 +370,7 @@ class Tuhi(GObject.Object):
             config = self.config.devices[bluez_device.address]
             uuid = config['uuid']
         except KeyError:
-            return
+            uuid = None
 
         # if we got here from a currently live BlueZ device,
         # ManufacturerData is reliable. Else, consider the device not in


### PR DESCRIPTION
Regression introduced in e1a3675439116c00a5bd5e14b5b539b0193db59e

Where a device has no config entry, the e1a367 change would return early. This
is fine for devices previously seen and still lingering in the config but for
completely new devices, we'll never get past that KeyError.

Return to the old behaviour: where we don't have a stored UUID we continue
with the None UUID.

Fixes #148