### PR TITLE
Add an argument to control the config dir

### DIFF
--- a/tuhi.in
+++ b/tuhi.in
@@ -11,6 +11,7 @@
 #  GNU General Public License for more details.
 #
 
+import sys
 import os
 import subprocess
 
@@ -21,9 +22,10 @@ tuhi_gui = os.path.join('@libexecdir@', 'tuhi-gui')
 @devel@  # NOQA
 
 if __name__ == '__main__':
-    tuhi = subprocess.Popen(tuhi_server)
+    args = sys.argv[1:]
+    tuhi = subprocess.Popen([tuhi_server] + args)
     try:
-        subprocess.run(tuhi_gui)
+        subprocess.run([tuhi_gui] + args)
     except KeyboardInterrupt:
         pass
     tuhi.terminate()

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -288,7 +288,7 @@ class Tuhi(GObject.Object):
             (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
-    def __init__(self):
+    def __init__(self, config_dir=None):
         GObject.Object.__init__(self)
         self.server = TuhiDBusServer()
         self.server.connect('bus-name-acquired', self._on_tuhi_bus_name_acquired)
@@ -299,7 +299,7 @@ class Tuhi(GObject.Object):
         self.bluez.connect('discovery-started', self._on_bluez_discovery_started)
         self.bluez.connect('discovery-stopped', self._on_bluez_discovery_stopped)
 
-        self.config = TuhiConfig()
+        self.config = TuhiConfig(config_dir)
 
         self.devices = {}
 
@@ -427,6 +427,10 @@ def main(args=sys.argv):
                         help='Show some debugging informations',
                         action='store_true',
                         default=False)
+    parser.add_argument('--config-dir',
+                        help='Base directory for configuration',
+                        type=str,
+                        default=None)
 
     ns = parser.parse_args(args[1:])
     if ns.verbose:
@@ -434,7 +438,7 @@ def main(args=sys.argv):
 
     try:
         mainloop = GLib.MainLoop()
-        tuhi = Tuhi()
+        tuhi = Tuhi(config_dir=ns.config_dir)
         tuhi.connect('terminate', lambda tuhi: mainloop.quit())
         mainloop.run()
     except KeyboardInterrupt:


### PR DESCRIPTION
Sits on top of #149 

This is useful for testing (`--config-dir=/tmp/$(date)`) but can also be useful when you're debugging Flatpak issues with a non-flatpak run.