### PR TITLE
Rework the message handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - run:
           command: |
-            dnf install -y meson gettext python3-devel pygobject3-devel python3-flake8 desktop-file-utils libappstream-glib
+            dnf install -y meson gettext python3-devel pygobject3-devel python3-flake8 desktop-file-utils libappstream-glib python3-pytest
       - checkout
       - run:
           command: |

--- a/meson.build
+++ b/meson.build
@@ -128,6 +128,10 @@ if flake8.found()
         args: ['--ignore=E501,W504',
                join_paths(meson.source_root(), 'tuhigui/'),
                join_paths(meson.source_root(), 'tuhi/')])
+   # the tests need different flake exclusions
+   test('flake8-tests', flake8,
+        args: ['--ignore=E501,W504,F403,F405',
+               join_paths(meson.source_root(), 'test/')])
 endif
 
 desktop_validate = find_program('desktop-file-validate', required: false)
@@ -139,6 +143,12 @@ appstream_util = find_program('appstream-util', required: false)
 if appstream_util.found()
     test('appstream-util validate-relax', appstream_util,
          args: ['validate-relax', appdata])
+endif
+
+pytest = find_program('pytest-3', required: false)
+if pytest.found()
+    test('unittest', pytest,
+         args: [join_paths(meson.source_root(), 'test')])
 endif
 
 # A wrapper to start tuhi at the same time as tuhigui, used by the flatpak

--- a/test/test_messages.py
+++ b/test/test_messages.py
@@ -1,0 +1,507 @@
+#!/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import calendar
+import os
+import sys
+import unittest
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)) + '/..')  # noqa
+
+from tuhi.protocol import *
+
+
+SUCCESS = NordicData([0xb3, 0x1, 0x00])
+
+
+class TestUtils(unittest.TestCase):
+    def test_hex_string(self):
+        values = [
+            ([0x00, 0x12], '00 12'),
+            ([0x00], '00'),
+            ([0xab], 'ab'),
+            ([0x00, 0x12, 0xab, 0xdf], '00 12 ab df'),
+            ((16).to_bytes(1, byteorder='little'), '10'),
+            ((1024).to_bytes(2, byteorder='little'), '00 04'),
+            ([], '')
+        ]
+
+        for v in values:
+            self.assertEqual(as_hex_string(v[0]), v[1])
+
+        with self.assertRaises(ValueError):
+            as_hex_string(1)
+
+        with self.assertRaises(ValueError):
+            as_hex_string('0x00')
+
+    def test_protocol_version(self):
+        values = [
+            ('INTUOS_PRO', ProtocolVersion.INTUOS_PRO),
+            ('intuos_pro', ProtocolVersion.INTUOS_PRO),
+            ('intuos-pro', ProtocolVersion.INTUOS_PRO),
+            ('SLATE', ProtocolVersion.SLATE),
+            ('slate', ProtocolVersion.SLATE),
+            ('SPARK', ProtocolVersion.SPARK),
+            ('spark', ProtocolVersion.SPARK),
+        ]
+
+        for v in values:
+            self.assertEqual(ProtocolVersion.from_string(v[0]), v[1])
+
+        # No real reason we couldn't support those but right now they
+        # aren't, so let's test for it.
+        with self.assertRaises(ValueError):
+            ProtocolVersion.from_string('Slate')
+
+        with self.assertRaises(ValueError):
+            ProtocolVersion.from_string('IntuosPro')
+
+
+class TestProtocolAny(unittest.TestCase):
+    protocol_version = ProtocolVersion.ANY
+
+    def test_get_protocol(self):
+        self.assertIsNotNone(Protocol(self.protocol_version, callback=None))
+
+    def test_has_all_messages(self):
+        p = Protocol(self.protocol_version, callback=None)
+        for m in Interactions:
+            # Some messages expect an argument and fail, that's fine for
+            # this test. We're looking for KeyErrors here if a message
+            # doesn't exist so we try each message with one of the likely
+            # arguments that will pass
+            args = [None, '101010', [0x12], Mode.LIVE]
+            for arg in args:
+                try:
+                    if arg is None:
+                        p.get(m)
+                    else:
+                        p.get(m, arg)
+                except TypeError:
+                    pass
+                except ValueError:
+                    pass
+                else:
+                    break
+
+    def test_connect(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xe6)
+            self.assertEqual(request.length, 6)
+            return SUCCESS
+
+        if cb is None:
+            cb = _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        with self.assertRaises(TypeError):
+            p.execute(Interactions.CONNECT)  # missing argument
+
+        uuid = 'abcdef123456'
+        msg = p.execute(Interactions.CONNECT, uuid)
+        self.assertEqual(msg.uuid, uuid)
+
+        with self.assertRaises(ValueError):
+            p.execute(Interactions.CONNECT, 'too-long-an-id')
+
+        with self.assertRaises(binascii.Error):
+            uuid = 'uvwxyz123456'
+            p.execute(Interactions.CONNECT, uuid)
+
+    def test_get_name(self, cb=None, name='test dev name'):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xbb)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            return NordicData([0xbc, len(name)] + list(bytes(name, encoding='ascii')))
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.GET_NAME)
+        self.assertEqual(msg.name, name)
+
+    def test_set_name(self, cb=None, name='test dev name'):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xbb)
+            self.assertEqual(request.length, len(name) + 1)
+            self.assertEqual(request[-1], 0xa)  # spark needs a trailing linebreak
+            self.assertEqual(bytes(request[:-1]).decode('utf-8'), name)
+            return SUCCESS
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        p.execute(Interactions.SET_NAME, name=name)
+
+    def test_get_time(self, cb=None, ts=time.time()):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xb6)
+            self.assertEqual(request.length, 1)
+            t = time.strftime('%y%m%d%H%M%S', time.gmtime(ts))
+            t = [int(i) for i in binascii.unhexlify(t)]
+            return NordicData([0xbd, len(t)] + t)
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.GET_TIME)
+        self.assertEqual(msg.timestamp, int(ts))
+
+    def test_set_time(self, cb=None, ts=time.time()):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xb6)
+            self.assertEqual(request.length, 6)
+            str_timestamp = ''.join([f'{b:02x}' for b in request])
+            t = calendar.timegm(time.strptime(str_timestamp, '%y%m%d%H%M%S'))
+            self.assertEqual(int(t), int(ts))
+            return SUCCESS
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        p.execute(Interactions.SET_TIME, timestamp=ts)
+
+    def test_get_fw(self, cb=None, fw='abcdef-123456'):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xb7)
+            self.assertEqual(request.length, 1)
+            data = [int(c, 16) for c in fw.split('-')[request[0]]]
+            return NordicData([0xb8, len(data) + 1, 0x00] + data)
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.GET_FIRMWARE)
+        self.assertEqual(msg.firmware, fw)
+
+    def test_get_battery(self, cb=None, battery=(1, 78)):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xb9)
+            self.assertEqual(request.length, 1)
+            return NordicData([0xba, 2, battery[1], battery[0]])
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.GET_BATTERY)
+        self.assertEqual(msg.battery_is_charging, battery[0])
+        self.assertEqual(msg.battery_percent, battery[1])
+
+    def test_get_width(self, cb=None, width=1234):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xea)
+            self.assertEqual(request.length, 2)
+            self.assertEqual(request[0], 3)
+
+            data = [0x03, 0x00] + list(width.to_bytes(4, byteorder='little'))
+            return NordicData([0xeb, len(data)] + data)
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.GET_WIDTH)
+        self.assertEqual(msg.width, width)
+
+    def test_get_height(self, cb=None, width=4321):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xea)
+            self.assertEqual(request.length, 2)
+            self.assertEqual(request[0], 4)
+
+            data = [0x04, 0x00] + list(width.to_bytes(4, byteorder='little'))
+            return NordicData([0xeb, len(data)] + data)
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.GET_HEIGHT)
+        self.assertEqual(msg.height, width)
+
+    def test_unknown_e3(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xe3)
+            self.assertEqual(request.length, 1)
+            return SUCCESS
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        p.execute(Interactions.UNKNOWN_E3)
+
+    def test_filetransfer_reporting_type(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xec)
+            self.assertEqual(request.length, 6)
+            self.assertEqual(request, [0x06, 0x00, 0x00, 0x00, 0x00, 0x00])
+            return SUCCESS
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        p.execute(Interactions.SET_FILE_TRANSFER_REPORTING_TYPE)
+
+    def test_set_mode(self, cb=None):
+        for mode in Mode:
+            mode = Mode.LIVE
+
+            def _cb(request, requires_reply=True, userdata=None, timeout=5):
+                self.assertEqual(request.opcode, 0xb1)
+                self.assertEqual(request.length, 1)
+                self.assertEqual(request[0], mode)
+                return SUCCESS
+
+            cb = cb or _cb
+
+            p = Protocol(self.protocol_version, callback=cb)
+            p.execute(Interactions.SET_MODE, mode)
+
+    def test_get_strokes(self, cb=None, count=1024, ts=time.time()):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            # this is a weird double call, see the protocol
+            # We reply 0xc7 first, and then 0xcd
+            if request is not None:
+                self.assertEqual(request.opcode, 0xc5)
+                self.assertEqual(request.length, 1)
+                self.assertEqual(request[0], 0x00)
+                data = list(count.to_bytes(4, byteorder='little'))
+                return NordicData([0xc7, len(data)] + data)
+            else:
+                t = time.strftime('%y%m%d%H%M%S', time.gmtime(ts))
+                data = [int(i) for i in binascii.unhexlify(t)]
+                return NordicData([0xcd, len(data)] + data)
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.GET_STROKES)
+        self.assertEqual(msg.count, count)
+        self.assertEqual(msg.timestamp, int(ts))
+
+    def test_get_data_available(self, cb=None, ndata=1234):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xc1)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            data = list(ndata.to_bytes(2, byteorder='big'))
+            return NordicData([0xc2, len(data)] + data)
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.GET_DATA_AVAILABLE)
+        self.assertEqual(msg.count, ndata)
+
+    def test_start_reading(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xc3)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            return NordicData([0xc8, 1, 0xbe])
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        p.execute(Interactions.START_READING)
+
+    def test_ack_transaction(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xca)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            # no reply
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        p.execute(Interactions.ACK_TRANSACTION)
+
+    def test_register_complete(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xe5)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            return SUCCESS
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        p.execute(Interactions.REGISTER_COMPLETE)
+
+    def test_register_press_button(self, cb=None, uuid=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xe3)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x01)
+            # no reply
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.REGISTER_PRESS_BUTTON, uuid=uuid)
+        self.assertEqual(msg.uuid, uuid)
+
+
+class TestProtocolSpark(TestProtocolAny):
+    protocol_version = ProtocolVersion.SPARK
+
+    def test_register_wait_for_button(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertIsNone(request)
+            return NordicData([0xe4, 0x00])
+
+        cb = cb or _cb
+
+        p = Protocol(self.protocol_version, callback=cb)
+        msg = p.execute(Interactions.REGISTER_WAIT_FOR_BUTTON)
+        self.assertEqual(msg.protocol_version, self.protocol_version)
+
+
+class TestProtocolSlate(TestProtocolSpark):
+    protocol_version = ProtocolVersion.SLATE
+
+    def test_get_strokes(self, cb=None, count=1024, ts=time.time()):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xcc)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            c = list(count.to_bytes(4, byteorder='little'))
+            t = time.strftime('%y%m%d%H%M%S', time.gmtime(ts))
+            t = [int(i) for i in binascii.unhexlify(t)]
+            data = c + t
+            return NordicData([0xcf, len(data)] + data)
+
+        super().test_get_strokes(cb or _cb, count=count, ts=ts)
+
+    def test_get_data_available(self, cb=None, ndata=1234):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xc1)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            data = list(ndata.to_bytes(2, byteorder='little'))
+            return NordicData([0xc2, len(data)] + data)
+
+        super().test_get_data_available(cb or _cb, ndata=ndata)
+
+    def test_ack_transaction(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xca)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            return SUCCESS
+
+        super().test_ack_transaction(cb or _cb)
+
+    def test_register_press_button(self, cb=None, uuid='abcdef123456'):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xe7)
+            self.assertEqual(request.length, 6)
+            # no reply
+
+        super().test_register_press_button(cb or _cb, uuid)
+
+    def test_register_wait_for_button(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertIsNone(request)
+            return NordicData([0xe4, 0x00])
+
+        super().test_register_wait_for_button(cb or _cb)
+
+
+class TestProtocolIntuosPro(TestProtocolSlate):
+    protocol_version = ProtocolVersion.INTUOS_PRO
+
+    def test_connect(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xe6)
+            self.assertEqual(request.length, 6)
+            return NordicData([0x50, 0x06] + request)  # replies with the uuid
+
+        super().test_connect(cb or _cb)
+
+    def test_get_name(self, cb=None, name='test dev name'):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xdb)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            return NordicData([0xbc, len(name)] + list(bytes(name, encoding='ascii')))
+
+        super().test_get_name(cb or _cb, name=name)
+
+    def test_set_name(self, cb=None, name='test dev name'):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xdb)
+            self.assertEqual(request.length, len(name))
+            self.assertEqual(bytes(request).decode('utf-8'), name)
+            return SUCCESS
+
+        super().test_set_name(cb or _cb, name=name)
+
+    def test_get_time(self, cb=None, ts=time.time()):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xd6)
+            self.assertEqual(request.length, 1)
+            t = list(int(ts).to_bytes(length=4, byteorder='little')) + [0x00, 0x00]
+            return NordicData([0xbd, len(t)] + t)
+
+        super().test_get_time(cb or _cb, ts=ts)
+
+    def test_set_time(self, cb=None, ts=time.time()):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xb6)
+            self.assertEqual(request.length, 6)
+            t = int.from_bytes(request[0:4], byteorder='little')
+            self.assertEqual(int(t), int(ts))
+            return SUCCESS
+
+        super().test_set_time(cb or _cb, ts=ts)
+
+    def test_get_fw(self, cb=None, fw='anything-string'):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xb7)
+            self.assertEqual(request.length, 1)
+            data = bytes(fw.split('-')[request[0]].encode('utf8'))
+            return NordicData([0xb8, len(data) + 1, 0x00] + list(data))
+
+        super().test_get_fw(cb or _cb, fw=fw)
+
+    def test_get_strokes(self, cb=None, count=1024, ts=time.time()):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertEqual(request.opcode, 0xcc)
+            self.assertEqual(request.length, 1)
+            self.assertEqual(request[0], 0x00)
+            c = list(count.to_bytes(4, byteorder='little'))
+            t = list(int(ts).to_bytes(4, byteorder='little'))
+            data = c + t
+            return NordicData([0xcf, len(data)] + data)
+
+        super().test_get_strokes(cb or _cb, count=count, ts=ts)
+
+    def test_register_wait_for_button(self, cb=None):
+        def _cb(request, requires_reply=True, userdata=None, timeout=5):
+            self.assertIsNone(request)
+            return NordicData([0x53, 0x00])
+
+        super().test_register_wait_for_button(cb or _cb)
+
+
+if __name__ == "__main__":
+    unittest.main(sys.argv[1:])

--- a/tuhi.in
+++ b/tuhi.in
@@ -11,6 +11,7 @@
 #  GNU General Public License for more details.
 #
 
+import sys
 import os
 import subprocess
 
@@ -21,9 +22,10 @@ tuhi_gui = os.path.join('@libexecdir@', 'tuhi-gui')
 @devel@  # NOQA
 
 if __name__ == '__main__':
-    tuhi = subprocess.Popen(tuhi_server)
+    args = sys.argv[1:]
+    tuhi = subprocess.Popen([tuhi_server] + args)
     try:
-        subprocess.run(tuhi_gui)
+        subprocess.run([tuhi_gui] + args)
     except KeyboardInterrupt:
         pass
     tuhi.terminate()

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -288,7 +288,7 @@ class Tuhi(GObject.Object):
             (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
-    def __init__(self):
+    def __init__(self, config_dir=None):
         GObject.Object.__init__(self)
         self.server = TuhiDBusServer()
         self.server.connect('bus-name-acquired', self._on_tuhi_bus_name_acquired)
@@ -299,7 +299,7 @@ class Tuhi(GObject.Object):
         self.bluez.connect('discovery-started', self._on_bluez_discovery_started)
         self.bluez.connect('discovery-stopped', self._on_bluez_discovery_stopped)
 
-        self.config = TuhiConfig()
+        self.config = TuhiConfig(config_dir)
 
         self.devices = {}
 
@@ -427,6 +427,10 @@ def main(args=sys.argv):
                         help='Show some debugging informations',
                         action='store_true',
                         default=False)
+    parser.add_argument('--config-dir',
+                        help='Base directory for configuration',
+                        type=str,
+                        default=None)
 
     ns = parser.parse_args(args[1:])
     if ns.verbose:
@@ -434,7 +438,7 @@ def main(args=sys.argv):
 
     try:
         mainloop = GLib.MainLoop()
-        tuhi = Tuhi()
+        tuhi = Tuhi(config_dir=ns.config_dir)
         tuhi.connect('terminate', lambda tuhi: mainloop.quit())
         mainloop.run()
     except KeyboardInterrupt:

--- a/tuhi/config.py
+++ b/tuhi/config.py
@@ -19,7 +19,7 @@ import configparser
 import re
 import logging
 from .drawing import Drawing
-from .wacom import Protocol
+from .protocol import ProtocolVersion
 
 logger = logging.getLogger('tuhi.config')
 
@@ -73,13 +73,13 @@ class TuhiConfig(GObject.Object):
 
                 assert config['Device']['Address'] == entry.name
                 if 'Protocol' not in config['Device']:
-                    config['Device']['Protocol'] = Protocol.UNKNOWN.value
+                    config['Device']['Protocol'] = ProtocolVersion.ANY.name.lower()
                 self._devices[entry.name] = config['Device']
 
     def new_device(self, address, uuid, protocol):
         assert is_btaddr(address)
         assert len(uuid) == 12
-        assert protocol != Protocol.UNKNOWN
+        assert protocol != ProtocolVersion.ANY
 
         logger.debug(f'{address}: adding new config, UUID {uuid}')
         path = os.path.join(self.config_dir, address)
@@ -100,7 +100,7 @@ class TuhiConfig(GObject.Object):
         config['Device'] = {
             'Address': address,
             'UUID': uuid,
-            'Protocol': protocol.value,
+            'Protocol': protocol.name.lower(),
         }
 
         with open(path, 'w') as configfile:

--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -74,9 +74,9 @@ class Interactions(enum.Enum):
     REGISTER_PRESS_BUTTON = enum.auto()
     REGISTER_WAIT_FOR_BUTTON = enum.auto()
     REGISTER_COMPLETE = enum.auto()
+    SET_FILE_TRANSFER_REPORTING_TYPE = enum.auto()
 
     UNKNOWN_E3 = enum.auto()
-    UNKNOWN_EC = enum.auto()
 
 
 def as_hex_string(data):
@@ -806,8 +806,12 @@ class MsgUnknownE3Command(Msg):
     # no arguments, uses the default 0xb3 handler
 
 
-class MsgUnknownECCommand(Msg):
-    interaction = Interactions.UNKNOWN_EC
+class MsgSetFileTransferReportingType(Msg):
+    '''
+    Changes where the device needs to send the data to.
+    0x00 is on the FFEE0003 GATT.
+    '''
+    interaction = Interactions.SET_FILE_TRANSFER_REPORTING_TYPE
     opcode = 0xec
     protocol = ProtocolVersion.ANY
 

--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -75,7 +75,6 @@ class Interactions(enum.Enum):
     REGISTER_WAIT_FOR_BUTTON = enum.auto()
     REGISTER_COMPLETE = enum.auto()
 
-    UNKNOWN_B1 = enum.auto()
     UNKNOWN_E3 = enum.auto()
     UNKNOWN_EC = enum.auto()
 
@@ -815,18 +814,6 @@ class MsgUnknownECCommand(Msg):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.args = [0x06, 0x00, 0x00, 0x00, 0x00, 0x00]
-
-    # uses the default 0xb3 handler
-
-
-class MsgUnknownB1Command(Msg):
-    interaction = Interactions.UNKNOWN_B1
-    opcode = 0xb1
-    protocol = ProtocolVersion.ANY
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.args = [0x01]
 
     # uses the default 0xb3 handler
 

--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -166,6 +166,29 @@ class ProtocolVersion(enum.IntEnum):
     SLATE = 2
     INTUOS_PRO = 3
 
+    @classmethod
+    def from_string(cls, string):
+        '''
+        Return the Enum value for the given string, allowing for different
+        spellings. Specifically: INTUOS_PRO, intuos_pro and intuos-pro are
+        all allowed for the ``INTUOS_PRO`` enum value.
+
+        :raise ValueError: if the name cannot be mapped.
+        '''
+        names = {e.name: e for e in cls}
+        if string in names:
+            return names[string]
+
+        names = {e.name.lower(): e for e in cls}
+        if string in names:
+            return names[string]
+
+        names = {e.name.lower().replace('_', '-'): e for e in cls}
+        if string in names:
+            return names[string]
+
+        raise ValueError(string)
+
 
 class Mode(enum.IntEnum):
     '''
@@ -1065,8 +1088,8 @@ class MsgRegisterWaitForButtonSlateOrIntuosPro(Msg):
 
     def _handle_reply(self, reply):
         if reply.opcode == 0xe4:
-            self.protocol_version =  ProtocolVersion.SLATE
+            self.protocol_version = ProtocolVersion.SLATE
         elif reply.opcode == 0x53:
-            self.protocol_version =  ProtocolVersion.INTUOS_PRO
+            self.protocol_version = ProtocolVersion.INTUOS_PRO
         else:
             raise UnexpectedReply(reply)

--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -72,6 +72,7 @@ class Interactions(enum.Enum):
     START_READING = enum.auto()
     ACK_TRANSACTION = enum.auto()
     REGISTER_PRESS_BUTTON = enum.auto()
+    REGISTER_WAIT_FOR_BUTTON = enum.auto()
     REGISTER_COMPLETE = enum.auto()
 
     UNKNOWN_B1 = enum.auto()
@@ -996,29 +997,76 @@ class MsgRegisterCompleteSlate(Msg):
 class MsgRegisterPressButtonSpark(Msg):
     interaction = Interactions.REGISTER_PRESS_BUTTON
     opcode = 0xe3
-    protocol = ProtocolVersion.SLATE
+    protocol = ProtocolVersion.ANY
+    # Does not require a reply, the reply is sent in response to the
+    # physical button press.
+    requires_reply = False
 
-    # FIXME: this is almost certainly incomplete
-    def _handle_reply(self, reply):
-        if reply.opcode != 0xb3:
-            raise UnexpectedReply(reply)
+    # uuid is unused, just there so it's compatible with the slate message
+    def __init__(self, uuid=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.args = [0x01]
+        self.uuid = uuid
 
 
-class MsgRegisterPressButtonSlate(Msg):
+class MsgRegisterPressButtonSlateOrIntuosPro(Msg):
     interaction = Interactions.REGISTER_PRESS_BUTTON
     opcode = 0xe7
     protocol = ProtocolVersion.SLATE
+    # Does not require a reply, the reply is sent in response to the
+    # physical button press.
+    requires_reply = False
 
-    # FIXME: this is almost certainly incomplete
+    def __init__(self, uuid, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uuid = uuid
+        self.args = [int(i) for i in binascii.unhexlify(uuid)]
+
+
+class MsgRegisterWaitForButtonSpark(Msg):
+    '''
+    .. attribute:: protocol_version
+
+    The protocol version used by this device, according to this message.
+
+    '''
+    interaction = Interactions.REGISTER_WAIT_FOR_BUTTON
+    requires_request = False
+    opcode = 0x00  # unused
+    protocol = ProtocolVersion.ANY
+
+    def __init__(self, *args, **kwargs):
+        kwargs['timeout'] = 10
+        super().__init__(*args, **kwargs)
+        self.protocol_version = ProtocolVersion.ANY
+
     def _handle_reply(self, reply):
         if reply.opcode != 0xe4:
             raise UnexpectedReply(reply)
+        self.protocol_version = ProtocolVersion.SPARK
 
 
-class MsgRegisterPressButtonIntuosPro(Msg):
-    interaction = Interactions.REGISTER_PRESS_BUTTON
-    opcode = 0xe7
+class MsgRegisterWaitForButtonSlateOrIntuosPro(Msg):
+    '''
+    .. attribute:: protocol_version
+
+    The protocol version used by this device, according to this message.
+
+    '''
+    interaction = Interactions.REGISTER_WAIT_FOR_BUTTON
+    requires_request = False
+    opcode = 0x00  # unused
+    protocol = ProtocolVersion.SLATE
+
+    def __init__(self, *args, **kwargs):
+        kwargs['timeout'] = 10
+        super().__init__(*args, **kwargs)
+        self.protocol_version = ProtocolVersion.ANY
 
     def _handle_reply(self, reply):
-        if reply.opcode != 0x53:
+        if reply.opcode == 0xe4:
+            self.protocol_version =  ProtocolVersion.SLATE
+        elif reply.opcode == 0x53:
+            self.protocol_version =  ProtocolVersion.INTUOS_PRO
+        else:
             raise UnexpectedReply(reply)

--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -1,0 +1,1022 @@
+#!/usr/bin/env python3
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+
+# Implementation of the BLE protocol of the Wacom SmartPad devices.
+#
+# Each device has a different set of functionalities and uses different
+# opcodes and message formats. So the entry point is the Protocol class, and
+# the messages can be accessed by key.
+#
+#     def my_callback(request, requires_reply=True, userdata=None):
+#        if request is not None:
+#            send_to_device(request)
+#        if requires_reply:
+#            return read_from device()
+#
+#     p = Protocol(ProtocolVersion.INTUOS_PRO, my_callback, userdata)
+#     m1 = P.get(Interactions.GET_NAME)
+#     m2 = P.get(Interactions.SET_NAME, 'SomeName')
+#
+# Each message is defined by a string (see INTERACTIONS) and takes the obvious
+# parameters where applicable.
+# The message itself is the protocol-specific Msg, a single logical interaction
+# with the device.
+#
+# The data exchange is prompted by the execute() function, which sets the
+# attributes on the message and can be chained where appropriate, e.g.
+#
+#    name = m1.execute().name
+#    if name != 'SomeName':
+#       m2.execute()
+#
+# Because we generally expect everything to work fine and where it doesn't
+# it affects a few things anyway, so error handling is via exceptions.
+#
+#    sequence = [m1, m2, m3, ...]
+#    try:
+#         for msg in sequence:
+#             m.execute()
+#    except AuthorizationError:
+#       print("oops, we have the wrong uuid")
+#
+
+import binascii
+import enum
+import time
+
+
+class Interactions(enum.Enum):
+    '''All possible interactions with a device. Not all of these
+    interactions may be available on any specific device.'''
+    CONNECT = enum.auto()
+    GET_NAME = enum.auto()
+    SET_NAME = enum.auto()
+    GET_TIME = enum.auto()
+    SET_TIME = enum.auto()
+    GET_FIRMWARE = enum.auto()
+    GET_BATTERY = enum.auto()
+    GET_DIMENSIONS = enum.auto()
+    SET_MODE = enum.auto()
+    GET_STROKES = enum.auto()
+    GET_DATA_AVAILABLE = enum.auto()
+    START_READING = enum.auto()
+    ACK_TRANSACTION = enum.auto()
+    REGISTER_PRESS_BUTTON = enum.auto()
+    REGISTER_COMPLETE = enum.auto()
+
+    UNKNOWN_B1 = enum.auto()
+    UNKNOWN_E3 = enum.auto()
+    UNKNOWN_EC = enum.auto()
+
+
+def as_hex_string(data):
+    '''
+    Returns the given byte-like to a debugging hex string in the form::
+
+        12 ab 34 cd 05 ..
+
+    Supports bytes and lists of integers.
+    '''
+    if isinstance(data, bytes):
+        hx = binascii.hexlify(data).decode('ascii')
+        return ' '.join([''.join(x) for x in zip(hx[::2], hx[1::2])])
+    elif isinstance(data, list):
+        return ' '.join([f'{x:02x}' for x in data])
+
+    raise ValueError('Unsupported data format {data.__class__} for {data}')
+
+
+def _get_protocol_dictionary(protocol):
+    '''
+    Returns a dict with the messages available for devices speaking that
+    particular protocol. These are classes, not objects, instantiate as
+    required. Usage::
+
+        pdict = get_protocol_dictionary(ProtocolVersion.ANY)
+        m = pdict[Interactions.GET_NAME]
+        print(m().execute().name)
+        m = pdict[Interactions.SET_NAME]
+        m('mynewname').execute()
+
+    The list of functions (``GET_NAME`` in the above example) depends on the
+    implementation state and may vary between devices.
+    '''
+    # Load all classes from this module
+    import sys
+    import inspect
+    classes = inspect.getmembers(sys.modules[__name__],
+                                 lambda member: inspect.isclass(member) and
+                                     member.__module__ == __name__) # NOQA
+    # Filter to the ones with Msg as base class
+    msgs = []
+    for name, cls in classes:
+        if cls == Msg:
+            continue
+        base_classes = inspect.getmro(cls)
+        if Msg not in base_classes:
+            continue
+        msgs.append(cls)
+
+    # Now compile the protocol-specific LUT for all functions that we
+    # suppport
+    pdict = {}
+    for cls in msgs:
+        assert cls.opcode is not None
+        assert cls.interaction
+        assert cls.protocol >= ProtocolVersion.ANY
+
+        if cls.protocol > protocol:
+            continue
+
+        # Only take the latest version of a message
+        if cls.interaction in pdict and cls.protocol < pdict[cls.interaction].protocol:
+            continue
+        pdict[cls.interaction] = cls
+    return pdict
+
+
+@enum.unique
+class ProtocolVersion(enum.IntEnum):
+    '''
+    Protocol version numbers, named after the devices first encountered
+    on. These version numbers are purely for sorting between devices, i.e.
+    do not use the numeric values of this enum. That value may change
+    if we discover more devices that have states in between.
+
+    The exact behavior of each protocol is varied, but
+
+    * opcodes may differ between protocol versions,
+    * the data inside a message may differ between versions, nd
+    * some functionality may only be available in some versions but not
+      others.
+    '''
+    ANY = 0
+    SPARK = 1
+    SLATE = 2
+    INTUOS_PRO = 3
+
+
+class Mode(enum.IntEnum):
+    '''
+    The mode the tablet is in. ``LIVE`` mode is when the tablet reports pen
+    strokes immediately. ``IDLE`` is the live mode but without reporting.
+    ``PAPER`` is the normal mode, i.e. where we download drawings.
+    '''
+    LIVE = 0x00
+    PAPER = 0x01
+    IDLE = 0x02
+
+
+class Protocol(object):
+    '''
+    The main communication class.
+
+    :param protocol_version: a :class:`ProtocolVersion`
+    :param callback: the callback to invoke for any messages
+    :param userdata: optional data argument provided to the callback function
+    '''
+    def __init__(self, protocol_version, callback, userdata=None):
+        self.protocol_version = protocol_version
+        self.callback = callback
+        self.userdata = userdata
+        self.lut = _get_protocol_dictionary(protocol_version)
+
+    def get(self, key, *args, **kwargs):
+        '''
+        Return the message with the given :class:`Interactions` key. This
+        only returns the message but does not execute it. In most cases,
+        you want to use :func:`execute` instead.
+        '''
+        kwargs['callback'] = self.callback
+        kwargs['userdata'] = self.userdata
+        msg = self.lut[key]
+        return msg(*args, **kwargs)
+
+    def execute(self, key, *args, **kwargs):
+        '''
+        Execute the message with the given :class:`Interactions` key and (where
+        applicable) the arguments. This returns the already executed message
+        that has the attributes you'd expect.
+        '''
+        return self.get(key, *args, **kwargs).execute()
+
+
+class NordicData(list):
+    '''
+    A set of bytes as expected by the Nordic controller on the device.
+    First byte is the opcode, second byte is the data length, rest is data.
+
+    This is an abstraction of a list. Instantiate with the full raw data,
+    the list contents will just be the data bytes:
+
+    >>> data = NordicData([0xab, 4, 0x1, 0x2, 0x3, 0x4])
+    >>> data
+    [1, 2, 3, 4]
+    >>> data.opcode
+    0xab
+    >>> data.length
+    4
+    >>> len(data)
+    4
+
+    .. attribute:: opcode
+
+        The opcode for this message
+
+    .. attribute:: length
+
+        The data length of this message. This field is guaranteed to be
+        equivalent to len(data) or an exception is raised.
+
+    '''
+    def __init__(self, bs):
+        data = bs[2:]
+        super().__init__(data)
+        self.opcode = bs[0]
+        self.length = bs[1]
+        if self.length != len(data):
+            raise UnexpectedDataError(bs, f'Invalid data: length field {self.length}, data length is {len(data)}')
+
+    def __repr__(self):
+        return f'{self.opcode:02x} / {self.length:02x} / {as_hex_string(self)}'
+
+
+class ProtocolError(Exception):
+    '''
+    Base class for all Tuhi-protocol related errors.
+    '''
+    def __init__(self, message=None):
+        self.message = message
+
+
+class AuthorizationError(Exception):
+    '''
+    The device does not recognize our UUID.
+    '''
+    pass
+
+
+class UnexpectedReply(ProtocolError):
+    '''
+    Exception thrown when the reply from the device does not match the
+    opcodes we expected.
+
+    This is not an error coming from the device, this is an
+    implementation bug.
+
+    .. attribute:: msg
+
+        The Message that caused the unexpected reply.
+    '''
+    def __init__(self, msg, message=None):
+        super().__init__(message)
+        self.msg = msg
+
+    def __repr__(self):
+        return f'{self.__class__}: {self.msg}: {self.message}'
+
+
+class UnexpectedDataError(ProtocolError):
+    '''
+    Exception thrown when the data is invalid. This is either a bug in our
+    parsing or a genuine issue with the tablet, but more likely the former.
+
+    This is not an error coming from the device, this is an
+    implementation bug.
+
+    .. attribute:: bytes
+
+        The raw bytes that caused the unexpected data.
+    '''
+    def __init__(self, bytes, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.bytes = bytes
+
+    def __repr__(self):
+        return f'{self.__class__}: {self.bytes} - {self.message}'
+
+
+class DeviceError(ProtocolError):
+    '''
+    The device replied with an error. Check the error code for which error
+    exactly happened.
+
+    .. attribute:: errorcode
+
+        An error code indicating which error occured on the device.
+
+    '''
+    class ErrorCode(enum.IntEnum):
+        '''
+        List of protocol errors as used by the Device.
+
+        The error code ``SUCCESS`` is provided for convenience only, it is
+        filtered by the implementation and not used in an actual exception.
+        '''
+        SUCCESS = 0x0
+        GENERAL_ERROR = 0x1
+        INVALID_STATE = 0x2
+        READ_ONLY_PARAM = 0x3
+        COMMAND_NOT_SUPPORTED = 0x4
+
+    def __init__(self, errorcode, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.errorcode = DeviceError.ErrorCode(errorcode)
+
+
+class Msg(object):
+    '''
+    A single logical interaction (request + reply) with the Wacom device.
+    In some cases a :class:`Msg` may issue multiple requests and replies as
+    one logical unit, but that should be considered an implementation
+    detail.
+
+    :param callback: The callback to invoke to talk to the device. This
+                     function must take one :class:`NordicData` and an
+                     optional userdata argument and return one
+                     :class:`NordicData` with the reply.
+    :param userdata: The data passed to the callback.
+
+    .. attribute:: request
+
+        The :class:`NordicData` sent to the device
+
+    .. attribute:: reply
+
+        The :class:`NordicData` returned to the device
+
+    .. attribute:: errorcode
+
+        The :class:`DeviceError.ErrorCodeNordicData` from this message.
+
+    '''
+    opcode = None
+    ''' The message-specific opcode. Must be defined in the subclass '''
+    protocol = ProtocolVersion.ANY
+    '''Minimum supported protocol version'''
+    interaction = None
+    '''The dictionary name for this interaction (e.g. ``GET_TIME``). Must be
+       defined in the subclass'''
+    requires_reply = True
+    '''True if this message requires the caller to wait for a reply from the
+       device.'''
+    requires_request = True
+    '''True if this message sends something to the device.'''
+
+    OPCODE_NOOP = 'noop'
+    '''A custom opcode for a noop function. Used where functionality was
+       removed in later versions but to keep the caller stack simpler, we
+       just provide a noop Msg.'''
+
+    def __init__(self, callback, userdata=None):
+        super().__init__()
+        assert self.opcode is not None
+        assert self.protocol is not None
+        assert self.interaction is not None
+        self._callback = callback
+        self.errorcode = None
+        self.userdata = userdata
+        self.args = [0x00]  # Empty messages don't exist
+
+    @property
+    def args(self):
+        '''
+        The arguments sent to the device as list of integers. Default is
+        [0x00], i.e. a message of length 1 with a constant 0 as argument.
+        '''
+        return self._args
+
+    @args.setter
+    def args(self, args):
+        self._args = args
+
+    def _handle_reply(self, reply):
+        '''Override this in the subclass to handle the reply.
+
+        This is the default reply handler that deals with the 0xb3 ACK/Error
+        messages and throws the respective exceptions.
+
+        :param reply: A :class:`NordicData` object
+        '''
+        if reply.opcode != 0xb3:
+            raise UnexpectedReply(self)
+
+        if reply[0] != 0x00:
+            raise DeviceError(reply[0])
+
+    def execute(self):
+        '''
+        The function to trigger the actual communication. This function
+        succeeds or raises a Wacom*Exception on error.
+        '''
+        if self.opcode == Msg.OPCODE_NOOP:
+            return self  # allow chaining
+
+        self.request = NordicData([self.opcode, len(self.args or []), *(self.args or [])])
+        self.reply = self._callback(request=self.request if self.requires_request else None,
+                                    requires_reply=self.requires_reply,
+                                    userdata=self.userdata)
+        if self.requires_reply:
+            try:
+                self._handle_reply(self.reply)
+                # no exception? we can assume success
+                self.errorcode = DeviceError.ErrorCode.SUCCESS
+            except DeviceError as e:
+                self.errorcode = e.errorcode
+                raise e
+        return self  # allow chaining
+
+    def __repr__(self):
+        return f'{self.__class__}: {self.interaction} - {self.request} → {self.reply}'
+
+
+class MsgConnectIntuosPro(Msg):
+    interaction = Interactions.CONNECT
+    opcode = 0xe6
+    protocol = ProtocolVersion.INTUOS_PRO
+
+    def __init__(self, uuid, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uuid = uuid
+        self.args = [int(i) for i in binascii.unhexlify(uuid)]
+        if len(self.args) != 6:
+            raise ValueError('UUID must be 6 bytes long')
+
+    def _handle_reply(self, reply):
+        if reply.opcode == 0x50:
+            # maybe check reply.data == the uuid we sent
+            pass  # success
+        elif reply.opcode == 0x51:
+            # first 6 bytes are the uuuid we just sent
+            reason = reply[6]
+            if reason in [0x00, 0x03]:  # invalid state
+                raise DeviceError(DeviceError.ErrorCode.INVALID_STATE)
+            elif reason in [0x01, 0x02]:  # incorrect uuuid
+                raise AuthorizationError()
+            raise UnexpectedReply(reply, message=f'Unknown error code: {reason}')
+        else:
+            raise UnexpectedReply(reply)
+
+
+class MsgConnectSpark(Msg):
+    interaction = Interactions.CONNECT
+    opcode = 0xe6
+
+    def __init__(self, uuid, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.uuid = uuid
+        self.args = [int(i) for i in binascii.unhexlify(uuid)]
+        if len(self.args) != 6:
+            raise ValueError('UUID must be 6 bytes long')
+
+        # uses the default 0xb3 handler
+
+
+class MsgGetName(Msg):
+    '''
+    .. attribute:: name
+
+        The device name as reported by the device
+    '''
+    interaction = Interactions.GET_NAME
+    opcode = 0xbb
+    protocol = ProtocolVersion.ANY
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xbc:
+            raise UnexpectedReply(f'Unknown reply: {reply.opcode}')
+        self.name = bytes(reply).decode('utf-8')
+
+
+class MsgGetNameIntuosPro(Msg):
+    '''
+    .. attribute:: name
+
+        The device name as reported by the device
+    '''
+    interaction = Interactions.GET_NAME
+    opcode = 0xdb
+    protocol = ProtocolVersion.INTUOS_PRO
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xbc:
+            raise UnexpectedReply(self)
+        self.name = bytes(reply).decode('utf-8')
+
+
+class MsgSetName(Msg):
+    '''
+    :param name: The device name to set on the device
+
+    .. attribute:: name
+
+        The device name as set with this request
+    '''
+    interaction = Interactions.SET_NAME
+    opcode = 0xbb
+    protocol = ProtocolVersion.ANY
+
+    def __init__(self, name, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # On the Spark, the name needs a trailing linebreak, otherwise the
+        # firmware gets confused.
+        self.args = [ord(c) for c in name] + [0x0a]
+
+    # uses the default 0xb3 handler
+
+
+class MsgSetNameIntuosPro(Msg):
+    '''
+    :param name: The device name to set on the device
+
+    .. attribute:: name
+
+        The device name as set with this request
+    '''
+    interaction = Interactions.SET_NAME
+    opcode = 0xdb
+    protocol = ProtocolVersion.INTUOS_PRO
+
+    def __init__(self, name, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.args = [ord(c) for c in name]
+
+    # uses the default 0xb3 handler
+
+
+class MsgGetTime(Msg):
+    '''
+    .. attribute:: timestamp
+
+        The time in seconds since UNIX epoch
+    '''
+    interaction = Interactions.GET_TIME
+    opcode = 0xb6
+    protocol = ProtocolVersion.ANY
+
+    def _handle_reply(self, reply):
+        import calendar
+
+        if reply.opcode != 0xbd:
+            raise UnexpectedReply(self)
+
+        if reply.length != 6:
+            raise UnexpectedDataError(f'Invalid reply length: expected 6, have {reply.length}')
+
+        # Assumption: device is in UTC
+        str_timestamp = ''.join([f'{b:02x}' for b in reply])
+        t = time.strptime(str_timestamp, '%y%m%d%H%M%S')
+        self.timestamp = calendar.timegm(t)
+
+
+class MsgGetTimeIntuosPro(Msg):
+    '''
+    .. attribute:: timestamp
+
+        The time in seconds since UNIX epoch
+    '''
+    interaction = Interactions.GET_TIME
+    opcode = 0xd6
+    protocol = ProtocolVersion.INTUOS_PRO
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xbd:
+            raise UnexpectedReply(self)
+
+        if reply.length != 6:
+            raise UnexpectedDataError(f'Invalid reply length: expected 6, have {reply.length}')
+
+        self.timestamp = int.from_bytes(reply[0:4], byteorder='little')  # bytes[5:6] are ms
+
+
+class MsgSetTime(Msg):
+    '''
+    :param timestamp: The current time in seconds since UNIX epoch
+
+    .. attribute:: timestamp
+
+        The time in seconds since UNIX epoch
+    '''
+    interaction = Interactions.SET_TIME
+    opcode = 0xb6
+    protocol = ProtocolVersion.ANY
+
+    def __init__(self, timestamp, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.timestamp = int(timestamp)
+        # IntuosPro and later use the same request but a different time format
+        current_time = time.strftime('%y%m%d%H%M%S', time.gmtime(self.timestamp))
+        self.args = [int(i) for i in binascii.unhexlify(current_time)]
+
+        # uses the default 0xb3 handler
+
+
+class MsgSetTimeIntuosPro(Msg):
+    '''
+    :param timestamp: The current time in seconds since UNIX epoch
+
+    .. attribute:: timestamp
+
+        The time in seconds since UNIX epoch
+    '''
+    interaction = Interactions.SET_TIME
+    opcode = 0xb6
+    protocol = ProtocolVersion.INTUOS_PRO
+
+    def __init__(self, timestamp, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.timestamp = int(timestamp)
+        self.args = list(self.timestamp.to_bytes(length=4, byteorder='little')) + [0x00, 0x00]
+
+        # uses the default 0xb3 handler
+
+
+class MsgGetFirmwareVersion(Msg):
+    '''
+    .. attribute:: firmware
+
+        The firmware version as a string
+    '''
+    interaction = Interactions.GET_FIRMWARE
+    opcode = 0xb7
+    protocol = ProtocolVersion.ANY
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.args = [0]
+        self._lo = None
+        self._hi = None
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xb8:
+            raise UnexpectedReply(self)
+
+        if self.args[0] == 0:
+            self._hi = ''.join([hex(d)[2:] for d in reply[1:]])
+        elif self.args[0] == 1:
+            self._lo = ''.join([hex(d)[2:] for d in reply[1:]])
+
+        if self._hi is not None and self._lo is not None:
+            self.firmware = f'{self._hi}-{self._lo}'
+
+    def execute(self):
+        # We need two requests with different args to get the full
+        # firmware information
+        self.args = [0]
+        super().execute()
+        self.args = [1]
+        super().execute()
+        return self
+
+
+class MsgGetFirmwareVersionIntuosPro(Msg):
+    '''
+    .. attribute:: firmware
+
+        The firmware version as a string
+    '''
+    interaction = Interactions.GET_FIRMWARE
+    opcode = 0xb7
+    protocol = ProtocolVersion.INTUOS_PRO
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._lo = None
+        self._hi = None
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xb8:
+            raise UnexpectedReply(self)
+
+        if self.args[0] == 0:
+            self._hi = ''.join([chr(d) for d in reply[1:]])
+        elif self.args[0] == 1:
+            self._lo = ''.join([chr(d) for d in reply[1:]])
+
+        if self._hi is not None and self._lo is not None:
+            self.firmware = f'{self._hi}-{self._lo}'
+
+    def execute(self):
+        # We need two requests with different args to get the full
+        # firmware information
+        self.args = [0]
+        super().execute()
+        self.args = [1]
+        super().execute()
+        return self
+
+
+class MsgGetBattery(Msg):
+    '''
+    .. attribute:: battery_percent
+
+        The battery charge in percent
+
+    .. attribute:: battery_is_charging
+
+        ``True`` if charging, ``False`` if discharging
+    '''
+    interaction = Interactions.GET_BATTERY
+    opcode = 0xb9
+    protocol = ProtocolVersion.ANY
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xba:
+            raise UnexpectedReply(self)
+
+        self.battery_percent = int(reply[0])
+        self.battery_is_charging = reply[1] == 1
+
+
+class MsgGetDimensions(Msg):
+    '''
+    .. attribute:: width
+
+        The width of the tablet in points (mm/100)
+
+    .. attribute:: height
+
+        The height of the tablet in points (mm/100)
+    '''
+    interaction = Interactions.GET_DIMENSIONS
+    opcode = 0xea
+    protocol = ProtocolVersion.ANY
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xeb:
+            raise UnexpectedReply(self)
+
+        if self.args[0] not in [0x3, 0x4] or len(reply) != 6:
+            raise UnexpectedDataError(reply)
+
+        if self.args[0] == 0x3:
+            self.width = int.from_bytes(reply[2:4], byteorder='little')
+        if self.args[0] == 0x4:
+            self.height = int.from_bytes(reply[2:4], byteorder='little')
+
+    def execute(self):
+        # We need two requests with different args to get both w and h
+        self.args = [0x3, 0x00]
+        super().execute()
+        self.args = [0x4, 0x00]
+        super().execute()
+        return self
+
+
+class MsgUnknownE3Command(Msg):
+    interaction = Interactions.UNKNOWN_E3
+    opcode = 0xe3
+    protocol = ProtocolVersion.ANY
+
+    # no arguments, uses the default 0xb3 handler
+
+
+class MsgUnknownECCommand(Msg):
+    interaction = Interactions.UNKNOWN_EC
+    opcode = 0xec
+    protocol = ProtocolVersion.ANY
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.args = [0x06, 0x00, 0x00, 0x00, 0x00, 0x00]
+
+    # uses the default 0xb3 handler
+
+
+class MsgUnknownB1Command(Msg):
+    interaction = Interactions.UNKNOWN_B1
+    opcode = 0xb1
+    protocol = ProtocolVersion.ANY
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.args = [0x01]
+
+    # uses the default 0xb3 handler
+
+
+class MsgSetMode(Msg):
+    '''
+    :param mode: one of :class:`Mode`
+
+    .. attribute:: mode
+
+        The :class:`Mode` of the tablet
+    '''
+    interaction = Interactions.SET_MODE
+    opcode = 0xb1
+    protocol = ProtocolVersion.ANY
+
+    def __init__(self, mode, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mode = Mode(mode)
+        self.args = [int(mode)]
+
+    # uses the default 0xb3 handler
+
+
+class MsgGetStrokesSpark(Msg):
+    '''
+    .. attribute:: count
+
+        The number of drawings available
+
+    .. attribute:: timestamp
+
+        The timestamp of the strokes sequence
+    '''
+    interaction = Interactions.GET_STROKES
+    opcode = 0xc5
+    protocol = ProtocolVersion.ANY
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.count = 0
+
+    def _handle_reply(self, reply):
+        # This is an odd message, we have one request but one or two
+        # replies. The 0xc7 reply is sometimes missing, unclear though when.
+        if reply.opcode == 0xc7:
+            self.count = int.from_bytes(reply[0:4], byteorder='little')
+
+            # Re-execute the message but this time without a new request
+            self.requires_request = False
+            self.execute()
+            self.requires_request = True
+        elif reply.opcode == 0xcd:
+            import calendar
+
+            str_timestamp = ''.join([f'{d:02x}' for d in reply])
+            t = time.strptime(str_timestamp, '%y%m%d%H%M%S')
+            self.timestamp = calendar.timegm(t)
+        else:
+            raise UnexpectedReply(reply)
+
+
+class MsgGetStrokesSlate(Msg):
+    '''
+    .. attribute:: count
+
+        The number of drawings available
+
+    .. attribute:: timestamp
+
+        The timestamp of the strokes sequence in seconds since UNIX epoch
+    '''
+    interaction = Interactions.GET_STROKES
+    opcode = 0xcc
+    protocol = ProtocolVersion.SLATE
+
+    def _handle_reply(self, reply):
+        import calendar
+
+        if reply.opcode != 0xcf:
+            raise UnexpectedReply(reply)
+
+        self.count = int.from_bytes(reply[0:4], byteorder='little')
+        str_timestamp = ''.join([f'{d:02x}' for d in reply[4:]])
+        t = time.strptime(str_timestamp, '%y%m%d%H%M%S')
+        self.timestamp = calendar.timegm(t)
+
+
+class MsgGetStrokesIntuosPro(Msg):
+    '''
+    .. attribute:: count
+
+        The number of drawings available
+
+    .. attribute:: timestamp
+
+        The timestamp of the strokes sequence
+    '''
+    interaction = Interactions.GET_STROKES
+    opcode = 0xcc
+    protocol = ProtocolVersion.INTUOS_PRO
+
+    # same as the slate version, but the timestamp handling differs
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xcf:
+            raise UnexpectedReply(reply)
+
+        self.count = int.from_bytes(reply[0:4], byteorder='little')
+        seconds = int.from_bytes(reply[4:], byteorder='little')
+        self.timestamp = seconds
+
+
+class MsgGetDataAvailable(Msg):
+    '''
+    .. attribute:: count
+
+        The number of drawings available
+    '''
+    interaction = Interactions.GET_DATA_AVAILABLE
+    opcode = 0xc1
+    protocol = ProtocolVersion.ANY
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xc2:
+            raise UnexpectedReply(self)
+
+        self.count = int.from_bytes(reply[0:2], byteorder='big')
+
+
+class MsgGetDataAvailableSlate(Msg):
+    '''
+    .. attribute:: count
+
+        The number of drawings available
+    '''
+    interaction = Interactions.GET_DATA_AVAILABLE
+    opcode = 0xc1
+    protocol = ProtocolVersion.SLATE
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xc2:
+            raise UnexpectedReply(self)
+
+        self.count = int.from_bytes(reply[0:2], byteorder='little')
+
+
+class MsgStartReading(Msg):
+    interaction = Interactions.START_READING
+    opcode = 0xc3
+    protocol = ProtocolVersion.ANY
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xc8:
+            raise UnexpectedReply(self)
+
+        if reply[0] != 0xbe:
+            raise UnexpectedDataError(reply)
+
+
+class MsgAckTransaction(Msg):
+    interaction = Interactions.ACK_TRANSACTION
+    opcode = 0xca
+    protocol = ProtocolVersion.ANY
+    requires_reply = False
+
+
+class MsgAckTransactionSlate(Msg):
+    interaction = Interactions.ACK_TRANSACTION
+    opcode = 0xca
+    protocol = ProtocolVersion.SLATE
+
+    # uses the default 0xb3 handler
+
+
+class MsgRegisterComplete(Msg):
+    interaction = Interactions.REGISTER_COMPLETE
+    opcode = 0xe5
+    protocol = ProtocolVersion.ANY
+
+    # uses the default 0xb3 handler
+
+
+class MsgRegisterCompleteSlate(Msg):
+    '''A noop Msg. This message only exists for the Spark'''
+    interaction = Interactions.REGISTER_COMPLETE
+    opcode = Msg.OPCODE_NOOP
+    protocol = ProtocolVersion.SLATE
+
+
+class MsgRegisterPressButtonSpark(Msg):
+    interaction = Interactions.REGISTER_PRESS_BUTTON
+    opcode = 0xe3
+    protocol = ProtocolVersion.SLATE
+
+    # FIXME: this is almost certainly incomplete
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xb3:
+            raise UnexpectedReply(reply)
+
+
+class MsgRegisterPressButtonSlate(Msg):
+    interaction = Interactions.REGISTER_PRESS_BUTTON
+    opcode = 0xe7
+    protocol = ProtocolVersion.SLATE
+
+    # FIXME: this is almost certainly incomplete
+    def _handle_reply(self, reply):
+        if reply.opcode != 0xe4:
+            raise UnexpectedReply(reply)
+
+
+class MsgRegisterPressButtonIntuosPro(Msg):
+    interaction = Interactions.REGISTER_PRESS_BUTTON
+    opcode = 0xe7
+
+    def _handle_reply(self, reply):
+        if reply.opcode != 0x53:
+            raise UnexpectedReply(reply)

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -165,7 +165,7 @@ class DataLogger(object):
             return self.parent._recv(self.source, data)
 
     commands = {
-        0xb1: 'start/stop live',
+        0xb1: 'set mode',
         0xb6: 'set time',
         0xb7: 'get firmware',
         0xb9: 'read battery info',
@@ -743,7 +743,7 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
     def stop_live(self):
         self.p.execute(Interactions.SET_MODE, Mode.IDLE)
 
-    def b1_command(self):
+    def set_paper_mode(self):
         self.p.execute(Interactions.SET_MODE, Mode.PAPER).execute()
 
     def is_data_available(self):
@@ -886,7 +886,7 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
         return drawing
 
     def read_offline_data(self):
-        self.b1_command()
+        self.set_paper_mode()
         transaction_count = 0
         while self.is_data_available():
             count, timestamp = self.get_stroke_data()

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -1026,19 +1026,6 @@ class WacomProtocolSlate(WacomProtocolSpark):
     def _on_sysevent_data_received(self, name, value):
         self.fw_logger.sysevent.recv(value)
 
-    def ack_transaction(self):
-        self.p.execute(Interactions.ACK_TRANSACTION)
-
-    def is_data_available(self):
-        n = self.p.execute(Interactions.GET_DATA_AVAILABLE).count
-        logger.debug(f'Drawings available: {n}')
-        return n > 0
-
-    def get_stroke_data(self):
-        msg = self.p.execute(Interactions.GET_STROKES)
-        # logger.debug(f'cc returned {data} ')
-        return msg.count, msg.timestamp
-
     def register_device_finish(self):
         self.set_time()
         self.read_time()
@@ -1120,28 +1107,6 @@ class WacomProtocolIntuosPro(WacomProtocolSlate):
     def time_from_bytes(self, data):
         seconds = int.from_bytes(data[0:4], byteorder='little')
         return time.gmtime(seconds)
-
-    # set_time is identical to spark/slate except the timestamp format
-
-    def read_time(self):
-        timestamp = self.p.execute(Interactions.GET_TIME).timestamp
-
-        t = time.strftime('%y-%m-%d %H:%M:%S', time.localtime(timestamp))
-        logger.debug(f'device time: {t}')
-
-    def get_firmware_version(self):
-        fw = self.p.execute(Interactions.GET_FIRMWARE).firmware
-        logger.info(f'firmware is {fw}')
-
-    def get_name(self):
-        name = self.p.execute(Interactions.GET_NAME).name
-        logger.info(f'device name is {name}')
-
-    def set_name(self, name):
-        self.p.execute(Interactions.SET_NAME, name)
-
-    def check_connection(self):
-        self.p.execute(Interactions.CONNECT, self._uuid)
 
     def parse_pen_data_prefix(self, data):
         expected_prefix = b'\x67\x82\x69\x65'

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -677,11 +677,6 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
     def e3_command(self):
         self.p.execute(Interactions.UNKNOWN_E3)
 
-    def time_to_bytes(self):
-        # Device time is UTC
-        current_time = time.strftime('%y%m%d%H%M%S', time.gmtime())
-        return [int(i) for i in binascii.unhexlify(current_time)]
-
     @classmethod
     def time_from_bytes(self, data):
         assert len(data) >= 6
@@ -1062,10 +1057,6 @@ class WacomProtocolIntuosPro(WacomProtocolSlate):
     def __init__(self, device, uuid, protocol_version=ProtocolVersion.INTUOS_PRO):
         assert(protocol_version >= ProtocolVersion.INTUOS_PRO)
         super().__init__(device, uuid, protocol_version=protocol_version)
-
-    def time_to_bytes(self):
-        t = int(time.time())
-        return list(t.to_bytes(length=4, byteorder='little')) + [0x00, 0x00]
 
     @classmethod
     def time_from_bytes(self, data):

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -514,25 +514,6 @@ class WacomProtocolLowLevelComm(GObject.Object):
         elif data[0] != 0x00:
             raise WacomException(f'unknown error: {data[0]:02x}')
 
-    def send_nordic_command_sync(self,
-                                 command,
-                                 expected_opcode=0xb3,
-                                 arguments=None):
-        if arguments is None:
-            arguments = [0x00]
-
-        self.send_nordic_command(command, arguments)
-
-        if expected_opcode is None:
-            return None
-
-        args = self.wait_nordic_data(expected_opcode, 5)
-
-        if expected_opcode == 0xb3:  # generic ACK
-            self.check_ack(args)
-
-        return args
-
     # The callback used by the protocol messages
     def nordic_data_exchange(self, request, requires_reply=False,
                              userdata=None, timeout=None):

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -534,11 +534,12 @@ class WacomProtocolLowLevelComm(GObject.Object):
         return args
 
     # The callback used by the protocol messages
-    def nordic_data_exchange(self, request, requires_reply=False, userdata=None):
+    def nordic_data_exchange(self, request, requires_reply=False,
+                             userdata=None, timeout=None):
         if request is not None:
             self.send_nordic_command(request.opcode, request)
         if requires_reply:
-            return self.wait_nordic_data(expected_opcode=None, timeout=5)
+            return self.wait_nordic_data(expected_opcode=None, timeout=timeout or 5)
 
 
 class WacomRegisterHelper(WacomProtocolLowLevelComm):

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -716,9 +716,10 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
         return name
 
     def get_dimensions(self):
-        msg = self.p.execute(Interactions.GET_DIMENSIONS)
-        logger.info(f'dimensions: {msg.width}x{msg.height}')
-        return msg.width, msg.height
+        w = self.p.execute(Interactions.GET_WIDTH).width
+        h = self.p.execute(Interactions.GET_HEIGHT).height
+        logger.info(f'dimensions: {w}x{h}')
+        return w, h
 
     def select_transfer_gatt(self):
         self.p.execute(Interactions.SET_FILE_TRANSFER_REPORTING_TYPE)

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -545,6 +545,13 @@ class WacomProtocolLowLevelComm(GObject.Object):
 
         return args
 
+    # The callback used by the protocol messages
+    def nordic_data_exchange(self, request, requires_reply=False, userdata=None):
+        if request is not None:
+            self.send_nordic_command(request.opcode, request)
+        if requires_reply:
+            return self.wait_nordic_data(expected_opcode=None, timeout=5)
+
 
 class WacomRegisterHelper(WacomProtocolLowLevelComm):
     '''

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -720,8 +720,8 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
         logger.info(f'dimensions: {msg.width}x{msg.height}')
         return msg.width, msg.height
 
-    def ec_command(self):
-        self.p.execute(Interactions.UNKNOWN_EC)
+    def select_transfer_gatt(self):
+        self.p.execute(Interactions.SET_FILE_TRANSFER_REPORTING_TYPE)
 
     def start_live(self, fd):
         self.p.execute(Interactions.SET_MODE, Mode.LIVE)
@@ -992,7 +992,7 @@ class WacomProtocolSlate(WacomProtocolSpark):
     def register_device_finish(self):
         self.set_time()
         self.read_time()
-        self.ec_command()
+        self.select_transfer_gatt()
         self.get_name()
 
         w, h = self.get_dimensions()
@@ -1016,7 +1016,7 @@ class WacomProtocolSlate(WacomProtocolSpark):
             self.notify('dimensions')
 
             self.get_firmware_version()
-            self.ec_command()
+            self.select_transfer_gatt()
             if self.read_offline_data() == 0:
                 logger.info('no data to retrieve')
         except WacomEEAGAINException:

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -503,11 +503,11 @@ class WacomProtocolLowLevelComm(GObject.Object):
 
         # logger.debug(f'received {data.opcode:02x} / {data.length:02x} / {b2hex(bytes(data))}')
 
-        if not isinstance(expected_opcode, list):
-            expected_opcode = [expected_opcode]
-
-        if data.opcode not in expected_opcode:
-            raise WacomException(f'unexpected opcode: {data.opcode:02x}')
+        if expected_opcode is not None:
+            if not isinstance(expected_opcode, list):
+                expected_opcode = [expected_opcode]
+            if data.opcode not in expected_opcode:
+                raise WacomException(f'unexpected opcode: {data.opcode:02x}')
 
         return data
 

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -864,13 +864,11 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
 
     def parse_pen_data(self, data, timestamp):
         '''
-        :param timestamp: a tuple with 9 entries, corresponding to the
-        local time
+        :param timestamp: seconds since UNIX epoch
         '''
         x, y, p = 0, 0, 0
         dx, dy, dp = 0, 0, 0
 
-        timestamp = int(calendar.timegm(timestamp))
         stroke = None
 
         success, offset = self.parse_pen_data_prefix(data)
@@ -926,13 +924,12 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
         transaction_count = 0
         while self.is_data_available():
             count, timestamp = self.get_stroke_data()
-            t = time.gmtime(timestamp)
-            logger.info(f'receiving {count} bytes drawn on UTC {time.strftime("%y%m%d%H%M%S", t)}')
+            logger.info(f'receiving {count} bytes drawn on UTC {time.strftime("%y%m%d%H%M%S", time.gmtime(timestamp))}')
             self.start_reading()
             pen_data = self.wait_for_end_read()
             str_pen = binascii.hexlify(bytes(pen_data))
             logger.info(f'received {str_pen}')
-            drawing = self.parse_pen_data(pen_data, t)
+            drawing = self.parse_pen_data(pen_data, timestamp)
             if drawing:
                 self.emit('drawing', drawing)
             self.ack_transaction()

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -25,6 +25,7 @@ import errno
 from gi.repository import GObject
 from .drawing import Drawing
 from .uhid import UHIDDevice
+from tuhi.protocol import NordicData
 
 logger = logging.getLogger('tuhi.wacom')
 
@@ -266,19 +267,6 @@ class DataLogger(object):
         self.logfile.write(f'  - send: {list2hexlist(data)}\n')
         if source != 'NORDIC':
             self.logfile.write(f'  source: {source}')
-
-
-class NordicData(list):
-    '''A set of bytes as expected by the Nordic controller on the device.
-    First byte is the opcode, second byte is the length, rest is data.
-
-    This is an abstraction of a list. Instantiate with the full raw data,
-    the list contents will just be the data bytes.
-    '''
-    def __init__(self, bs):
-        super().__init__(bs[2:])
-        self.opcode = bs[0]
-        self.length = bs[1]
 
 
 class WacomException(Exception):


### PR DESCRIPTION
This is on top of #150 

This is a large rework of how we talk to the device, with the main goal of separating out all the device-specific messages into a separate module and their own classes. This should make a few things easier long-term, specifically testing and debugging.

The pen data handling is still on the old approach, this only switches "normal" messages over. Registration works with the new message system too but it's a bit clunky.

Tested with the Intuos Pro and the Spark, both still work here.