### PR TITLE
Use pathlib instead of os.path

### DIFF
--- a/tools/kete.py
+++ b/tools/kete.py
@@ -28,9 +28,10 @@ import time
 import svgwrite
 import xdg.BaseDirectory
 import configparser
+from pathlib import Path
 
 
-CONFIG_PATH = os.path.join(xdg.BaseDirectory.xdg_data_home, 'tuhi-kete')
+CONFIG_PATH = Path(xdg.BaseDirectory.xdg_data_home, 'tuhi-kete')
 
 
 class ColorFormatter(logging.Formatter):
@@ -759,14 +760,11 @@ class TuhiKeteShell(cmd.Cmd):
         # patching get_names to hide some functions we do not want in the help
         self.get_names = self._filtered_get_names
 
-        try:
-            os.mkdir(CONFIG_PATH)
-        except FileExistsError:
-            pass
+        CONFIG_PATH.mkdir(exist_ok=True)
 
-        self._config_file = os.path.join(CONFIG_PATH, 'settings.ini')
+        self._config_file = Path(CONFIG_PATH, 'settings.ini')
         self._config = configparser.ConfigParser()
-        if os.path.exists(self._config_file):
+        if self._config_file.exists():
             self._config.read(self._config_file)
         else:
             # Populate config file with a configuration example
@@ -791,7 +789,7 @@ HandlePressure = true
 
 ''')
 
-        self._history_file = os.path.join(CONFIG_PATH, 'histfile')
+        self._history_file = Path(CONFIG_PATH, 'histfile')
 
         try:
             readline.read_history_file(self._history_file)

--- a/tools/kete.py
+++ b/tools/kete.py
@@ -33,6 +33,27 @@ from pathlib import Path
 
 CONFIG_PATH = Path(xdg.BaseDirectory.xdg_data_home, 'tuhi-kete')
 
+INI_TEMPLATE = \ # noqa
+'''
+# configuration file for kete
+
+# the file follows a standard .ini format:
+# each device should have its own section like the following
+# [Bluetooth Address]
+# in each section, possible keys are:
+# - Orientation (possible values: Portrait, Landscape,
+#                                 Reverse-Portrait, Reverse-Landscape
+#               defaults to Landscape)
+# - HandlePressure (possible values: true, false
+#                   defaults to false)
+
+
+# Example:
+[11:22:33:44:55:66]
+Orientation = Reverse-Portrait
+HandlePressure = true
+'''
+
 
 class ColorFormatter(logging.Formatter):
     BLACK, RED, GREEN, YELLOW, BLUE, MAGENTA, CYAN, LIGHT_GRAY = range(30, 38)
@@ -769,25 +790,7 @@ class TuhiKeteShell(cmd.Cmd):
         else:
             # Populate config file with a configuration example
             with open(self._config_file, 'w') as f:
-                f.write('''# configuration file for kete
-
-# the file follows a standard .ini format:
-# each device should have its own section like the following
-# [Bluetooth Address]
-# in each section, possible keys are:
-# - Orientation (possible values: Portrait, Landscape,
-#                                 Reverse-Portrait, Reverse-Landscape
-#               defaults to Landscape)
-# - HandlePressure (possible values: true, false
-#                   defaults to false)
-
-
-# Example:
-[11:22:33:44:55:66]
-Orientation = Reverse-Portrait
-HandlePressure = true
-
-''')
+                f.write(INI_TEMPLATE)
 
         self._history_file = Path(CONFIG_PATH, 'histfile')
 

--- a/tuhi-gui.in
+++ b/tuhi-gui.in
@@ -3,6 +3,7 @@
 import gi
 import sys
 import os
+from pathlib import Path
 
 gi.require_version('Gio', '2.0')  # NOQA
 gi.require_version('Gtk', '3.0')  # NOQA
@@ -10,7 +11,7 @@ from gi.repository import Gio, Gtk, Gdk
 
 
 @devel@  # NOQA
-resource = Gio.resource_load(os.path.join('@pkgdatadir@', 'tuhi.gresource'))
+resource = Gio.resource_load(os.fspath(Path('@pkgdatadir@', 'tuhi.gresource')))
 Gio.Resource._register(resource)
 
 

--- a/tuhi.in
+++ b/tuhi.in
@@ -12,11 +12,11 @@
 #
 
 import sys
-import os
 import subprocess
+from pathlib import Path
 
-tuhi_server = os.path.join('@libexecdir@', 'tuhi-server')
-tuhi_gui = os.path.join('@libexecdir@', 'tuhi-gui')
+tuhi_server = Path('@libexecdir@', 'tuhi-server')
+tuhi_gui = Path('@libexecdir@', 'tuhi-gui')
 
 
 @devel@  # NOQA

--- a/tuhi/gui/svg.py
+++ b/tuhi/gui/svg.py
@@ -16,21 +16,19 @@ from gi.repository import GObject
 import xdg.BaseDirectory
 import svgwrite
 import os
+from pathlib import Path
 
-DATA_PATH = os.path.join(xdg.BaseDirectory.xdg_data_home, 'tuhi', 'svg')
+DATA_PATH = Path(xdg.BaseDirectory.xdg_data_home, 'tuhi', 'svg')
 
 
 class JsonSvg(GObject.Object):
     def __init__(self, json, orientation, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.json = json
-        try:
-            os.mkdir(DATA_PATH)
-        except FileExistsError:
-            pass
+        DATA_PATH.mkdir(parents=True, exist_ok=True)
 
         self.timestamp = json['timestamp']
-        self.filename = os.path.join(DATA_PATH, f'{self.timestamp}.svg')
+        self.filename = os.fspath(Path(DATA_PATH, f'{self.timestamp}.svg'))
         self.orientation = orientation
         self._convert()
 

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -16,11 +16,11 @@ import binascii
 import enum
 import inspect
 import logging
-import os
 import threading
 import time
 import uuid
 import errno
+from pathlib import Path
 from gi.repository import GObject
 from .drawing import Drawing
 from .uhid import UHIDDevice
@@ -188,8 +188,8 @@ class DataLogger(object):
         self.logger = logging.getLogger('tuhi.fw')
         self.device = bluez_device
         self.btaddr = bluez_device.address
-        self.logdir = os.path.join(xdg.BaseDirectory.xdg_data_home, 'tuhi', self.btaddr, 'raw')
-        os.makedirs(self.logdir, exist_ok=True)
+        self.logdir = Path(xdg.BaseDirectory.xdg_data_home, 'tuhi', self.btaddr, 'raw')
+        self.logdir.mkdir(exist_ok=True)
 
         bluez_device.connect('connected', self._on_bluez_connected)
         bluez_device.connect('disconnected', self._on_bluez_disconnected)
@@ -212,7 +212,7 @@ class DataLogger(object):
         timestamp = int(time.time())
         t = time.strftime('%Y-%m-%d-%H:%M:%S')
         fname = f'log-{timestamp}-{t}.yaml'
-        path = os.path.join(self.logdir, fname)
+        path = Path(self.logdir, fname)
         self.logfile = open(path, 'w+')
 
         self.logfile.write(f'name: {self.device.name}\n')


### PR DESCRIPTION
pathlib is object-oriented and superior for any path handling. With the exception of gresources and svgwrite that don't take a pathlib object, but we can work around those two lines.