### PR TITLE
gui: store the cached SVGs in $XDG_CACHE_DIR instead

### DIFF
--- a/tuhi/gui/svg.py
+++ b/tuhi/gui/svg.py
@@ -18,7 +18,7 @@ import svgwrite
 import os
 from pathlib import Path
 
-DATA_PATH = Path(xdg.BaseDirectory.xdg_data_home, 'tuhi', 'svg')
+DATA_PATH = Path(xdg.BaseDirectory.xdg_cache_home, 'tuhi', 'svg')
 
 
 class JsonSvg(GObject.Object):


### PR DESCRIPTION
This is transient data, they're constantly regenerated. Let's store them as
such.