### PR TITLE
tools: fix syntax error in kete

### DIFF
--- a/tools/kete.py
+++ b/tools/kete.py
@@ -33,8 +33,7 @@ from pathlib import Path
 
 CONFIG_PATH = Path(xdg.BaseDirectory.xdg_data_home, 'tuhi-kete')
 
-INI_TEMPLATE = \ # noqa
-'''
+INI_TEMPLATE = '''
 # configuration file for kete
 
 # the file follows a standard .ini format:


### PR DESCRIPTION
Introduced in cc7ba1b365f55436db5eeb8ffd9f6df50015ee50 for slightly
overzealous flake8 handling.
