### PR TITLE
gui: simplify the Config's singleton pattern

### DIFF
--- a/tuhi/gui/config.py
+++ b/tuhi/gui/config.py
@@ -23,19 +23,24 @@ logger = logging.getLogger('tuhi.gui.config')
 
 
 class Config(GObject.Object):
-    _config_obj = None
+    _instance = None
     _base_path = None
 
-    def __init__(self):
-        super().__init__()
-        self.path = Path(self._base_path, 'tuhigui.ini')
-        self.base_path = self._base_path
-        self.config = configparser.ConfigParser()
-        # Don't lowercase options
-        self.config.optionxform = str
-        self._drawings = []
-        self._load()
-        self._load_cached_drawings()
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(Config, cls).__new__(cls)
+
+            self = cls._instance
+            self.__init__()  # for GObject to initialize
+            self.path = Path(self._base_path, 'tuhigui.ini')
+            self.base_path = self._base_path
+            self.config = configparser.ConfigParser()
+            # Don't lowercase options
+            self.config.optionxform = str
+            self._drawings = []
+            self._load()
+            self._load_cached_drawings()
+        return cls._instance
 
     def _load(self):
         if not self.path.exists():
@@ -122,14 +127,8 @@ class Config(GObject.Object):
 
     @classmethod
     def set_base_path(cls, path):
-        if cls._config_obj is not None:
+        if cls._instance is not None:
             logger.error('Trying to set config base path but we already have the singleton object')
             return
 
         cls._base_path = Path(path)
-
-    @classmethod
-    def instance(cls):
-        if cls._config_obj is None:
-            cls._config_obj = Config()
-        return cls._config_obj

--- a/tuhi/gui/drawing.py
+++ b/tuhi/gui/drawing.py
@@ -37,8 +37,8 @@ class Drawing(Gtk.EventBox):
 
     def __init__(self, json_data, *args, **kwargs):
         super().__init__()
-        self.orientation = Config.instance().orientation
-        Config.instance().connect('notify::orientation', self._on_orientation_changed)
+        self.orientation = Config().orientation
+        Config().connect('notify::orientation', self._on_orientation_changed)
         DATA_PATH.mkdir(parents=True, exist_ok=True)
 
         self.json_data = json_data
@@ -127,7 +127,7 @@ class Drawing(Gtk.EventBox):
 
     @Gtk.Template.Callback('_on_delete_button_clicked')
     def _on_delete_button_clicked(self, button):
-        Config.instance().delete_drawing(self.timestamp)
+        Config().delete_drawing(self.timestamp)
 
     @Gtk.Template.Callback('_on_rotate_button_clicked')
     def _on_rotate_button_clicked(self, button):

--- a/tuhi/gui/drawingperspective.py
+++ b/tuhi/gui/drawingperspective.py
@@ -80,7 +80,7 @@ class DrawingPerspective(Gtk.Stack):
         # The config backend filters duplicates anyway, so don't care here
         for ts in self.device.drawings_available:
             json_string = self.device.json(ts)
-            Config.instance().add_drawing(ts, json_string)
+            Config().add_drawing(ts, json_string)
 
     def _update_drawings(self, config, pspec):
         def _hash(drawing):
@@ -137,9 +137,9 @@ class DrawingPerspective(Gtk.Stack):
         # json itself (once cached) that we then actually use for SVG
         # generation.
         device.connect('notify::drawings-available', self._cache_drawings)
-        Config.instance().connect('notify::drawings', self._update_drawings)
+        Config().connect('notify::drawings', self._update_drawings)
 
-        self._update_drawings(Config.instance(), None)
+        self._update_drawings(Config(), None)
 
         # We always want to sync on startup
         logger.debug(f'{device.name} - starting to listen')
@@ -179,5 +179,5 @@ class DrawingPerspective(Gtk.Stack):
 
     @Gtk.Template.Callback('_on_undo_clicked')
     def _on_undo_clicked(self, button):
-        Config.instance().undelete_drawing(button.deleted_drawing)
+        Config().undelete_drawing(button.deleted_drawing)
         self.overlay_undo.set_reveal_child(False)

--- a/tuhi/gui/window.py
+++ b/tuhi/gui/window.py
@@ -136,7 +136,7 @@ class MainWindow(Gtk.ApplicationWindow):
         action = Gio.SimpleAction.new_stateful('orientation', GLib.VariantType('s'),
                                                GLib.Variant('s', 'landscape'))
         action.connect('activate', self._on_orientation_changed)
-        action.set_state(GLib.Variant.new_string(Config.instance().orientation))
+        action.set_state(GLib.Variant.new_string(Config().orientation))
         self.add_action(action)
 
         builder = Gtk.Builder.new_from_string(MENU_XML, -1)
@@ -234,7 +234,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
     def _on_orientation_changed(self, action, label):
         action.set_state(label)
-        Config.instance().orientation = label.get_string()  # this is a GVariant
+        Config().orientation = label.get_string()  # this is a GVariant
 
     @Gtk.Template.Callback('_on_zoom_changed')
     def _on_zoom_changed(self, adjustment):


### PR DESCRIPTION
Use `__new__` instead of `instance()`, this way we can just use the same config
object as `Config().do_something`.