### PR TITLE
Add a --keep-drawings option

### DIFF
--- a/test/test_messages.py
+++ b/test/test_messages.py
@@ -316,7 +316,7 @@ class TestProtocolAny(unittest.TestCase):
         self.assertEqual(msg.count, count)
         self.assertEqual(msg.timestamp, int(ts))
 
-    def test_get_data_available(self, cb=None, ndata=1234):
+    def test_available_files_count(self, cb=None, ndata=1234):
         def _cb(request, requires_reply=True, userdata=None, timeout=5):
             self.assertEqual(request.opcode, 0xc1)
             self.assertEqual(request.length, 1)
@@ -327,10 +327,10 @@ class TestProtocolAny(unittest.TestCase):
         cb = cb or _cb
 
         p = Protocol(self.protocol_version, callback=cb)
-        msg = p.execute(Interactions.GET_DATA_AVAILABLE)
+        msg = p.execute(Interactions.AVAILABLE_FILES_COUNT)
         self.assertEqual(msg.count, ndata)
 
-    def test_start_reading(self, cb=None):
+    def test_download_oldest_file(self, cb=None):
         def _cb(request, requires_reply=True, userdata=None, timeout=5):
             self.assertEqual(request.opcode, 0xc3)
             self.assertEqual(request.length, 1)
@@ -340,9 +340,9 @@ class TestProtocolAny(unittest.TestCase):
         cb = cb or _cb
 
         p = Protocol(self.protocol_version, callback=cb)
-        p.execute(Interactions.START_READING)
+        p.execute(Interactions.DOWNLOAD_OLDEST_FILE)
 
-    def test_ack_transaction(self, cb=None):
+    def test_delete_oldest_file(self, cb=None):
         def _cb(request, requires_reply=True, userdata=None, timeout=5):
             self.assertEqual(request.opcode, 0xca)
             self.assertEqual(request.length, 1)
@@ -352,7 +352,7 @@ class TestProtocolAny(unittest.TestCase):
         cb = cb or _cb
 
         p = Protocol(self.protocol_version, callback=cb)
-        p.execute(Interactions.ACK_TRANSACTION)
+        p.execute(Interactions.DELETE_OLDEST_FILE)
 
     def test_register_complete(self, cb=None):
         def _cb(request, requires_reply=True, userdata=None, timeout=5):
@@ -441,7 +441,7 @@ class TestProtocolSlate(TestProtocolSpark):
 
         super().test_get_strokes(cb or _cb, count=count, ts=ts)
 
-    def test_get_data_available(self, cb=None, ndata=1234):
+    def test_available_files_count(self, cb=None, ndata=1234):
         def _cb(request, requires_reply=True, userdata=None, timeout=5):
             self.assertEqual(request.opcode, 0xc1)
             self.assertEqual(request.length, 1)
@@ -449,16 +449,16 @@ class TestProtocolSlate(TestProtocolSpark):
             data = list(ndata.to_bytes(2, byteorder='little'))
             return NordicData([0xc2, len(data)] + data)
 
-        super().test_get_data_available(cb or _cb, ndata=ndata)
+        super().test_available_files_count(cb or _cb, ndata=ndata)
 
-    def test_ack_transaction(self, cb=None):
+    def test_delete_oldest_file(self, cb=None):
         def _cb(request, requires_reply=True, userdata=None, timeout=5):
             self.assertEqual(request.opcode, 0xca)
             self.assertEqual(request.length, 1)
             self.assertEqual(request[0], 0x00)
             return SUCCESS
 
-        super().test_ack_transaction(cb or _cb)
+        super().test_delete_oldest_file(cb or _cb)
 
     def test_register_press_button(self, cb=None, uuid='abcdef123456'):
         def _cb(request, requires_reply=True, userdata=None, timeout=5):

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -450,9 +450,14 @@ def main(args=sys.argv):
                         help='Base directory for configuration',
                         type=str,
                         default=DEFAULT_CONFIG_PATH)
+    parser.add_argument('--peek',
+                        help='Download first drawing only but do not remove it from the device',
+                        action='store_true',
+                        default=False)
 
     ns = parser.parse_args(args[1:])
     TuhiConfig.set_base_path(ns.config_dir)
+    TuhiConfig().peek_at_drawing = ns.peek
     setup_logging(ns.config_dir)
 
     if ns.verbose:

--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -302,7 +302,7 @@ class Tuhi(GObject.Object):
         self.bluez.connect('discovery-started', self._on_bluez_discovery_started)
         self.bluez.connect('discovery-stopped', self._on_bluez_discovery_stopped)
 
-        self.config = TuhiConfig(config_dir)
+        self.config = TuhiConfig()
 
         self.devices = {}
 
@@ -452,6 +452,7 @@ def main(args=sys.argv):
                         default=DEFAULT_CONFIG_PATH)
 
     ns = parser.parse_args(args[1:])
+    TuhiConfig.set_base_path(ns.config_dir)
     setup_logging(ns.config_dir)
 
     if ns.verbose:

--- a/tuhi/config.py
+++ b/tuhi/config.py
@@ -41,6 +41,7 @@ class TuhiConfig(GObject.Object):
 
             self._devices = {}
             self._scan_config_dir()
+            self.peek_at_drawing = False
         return cls._instance
 
     @GObject.Property

--- a/tuhi/gui/application.py
+++ b/tuhi/gui/application.py
@@ -46,6 +46,12 @@ class Application(Gtk.Application):
                              GLib.OptionFlags.NONE,
                              GLib.OptionArg.NONE,
                              'enable verbose output')
+        # unused, just here to have option compatibility with the tuhi
+        # server but we could add some GUI feedback here
+        self.add_main_option('peek', 0,
+                             GLib.OptionFlags.NONE,
+                             GLib.OptionArg.NONE,
+                             'download first drawing only but do not remove it from the device')
         self._tuhi = None
 
     def do_startup(self):

--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -116,9 +116,9 @@ class Interactions(enum.Enum):
     GET_HEIGHT = enum.auto()
     SET_MODE = enum.auto()
     GET_STROKES = enum.auto()
-    GET_DATA_AVAILABLE = enum.auto()
-    START_READING = enum.auto()
-    ACK_TRANSACTION = enum.auto()
+    AVAILABLE_FILES_COUNT = enum.auto()
+    DOWNLOAD_OLDEST_FILE = enum.auto()
+    DELETE_OLDEST_FILE = enum.auto()
     REGISTER_PRESS_BUTTON = enum.auto()
     REGISTER_WAIT_FOR_BUTTON = enum.auto()
     REGISTER_COMPLETE = enum.auto()
@@ -1087,13 +1087,13 @@ class MsgGetStrokesIntuosPro(Msg):
         self.timestamp = seconds
 
 
-class MsgGetDataAvailable(Msg):
+class MsgAvailableFilesCount(Msg):
     '''
     .. attribute:: count
 
         The number of drawings available
     '''
-    interaction = Interactions.GET_DATA_AVAILABLE
+    interaction = Interactions.AVAILABLE_FILES_COUNT
     opcode = 0xc1
     protocol = ProtocolVersion.ANY
 
@@ -1104,13 +1104,13 @@ class MsgGetDataAvailable(Msg):
         self.count = int.from_bytes(reply[0:2], byteorder='big')
 
 
-class MsgGetDataAvailableSlate(Msg):
+class MsgAvailableFilesCountSlate(Msg):
     '''
     .. attribute:: count
 
         The number of drawings available
     '''
-    interaction = Interactions.GET_DATA_AVAILABLE
+    interaction = Interactions.AVAILABLE_FILES_COUNT
     opcode = 0xc1
     protocol = ProtocolVersion.SLATE
 
@@ -1121,8 +1121,8 @@ class MsgGetDataAvailableSlate(Msg):
         self.count = little_u16(reply[0:2])
 
 
-class MsgStartReading(Msg):
-    interaction = Interactions.START_READING
+class MsgDownloadOldestFile(Msg):
+    interaction = Interactions.DOWNLOAD_OLDEST_FILE
     opcode = 0xc3
     protocol = ProtocolVersion.ANY
 
@@ -1134,15 +1134,15 @@ class MsgStartReading(Msg):
             raise UnexpectedDataError(reply)
 
 
-class MsgAckTransaction(Msg):
-    interaction = Interactions.ACK_TRANSACTION
+class MsgDeleteOldestFile(Msg):
+    interaction = Interactions.DELETE_OLDEST_FILE
     opcode = 0xca
     protocol = ProtocolVersion.ANY
     requires_reply = False
 
 
-class MsgAckTransactionSlate(Msg):
-    interaction = Interactions.ACK_TRANSACTION
+class MsgDeleteOldestFileSlate(Msg):
+    interaction = Interactions.DELETE_OLDEST_FILE
     opcode = 0xca
     protocol = ProtocolVersion.SLATE
 

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -688,7 +688,7 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
             battery, charging = self.get_battery_info()
             self.emit('battery-status', battery, charging)
             self.update_dimensions()
-            if self.read_offline_data() == 0:
+            if not self.read_offline_data():
                 logger.info('no data to retrieve')
         except WacomEEAGAINException:
             logger.warning('no data, please make sure the LED is blue and the button is pressed to switch it back to green')
@@ -745,8 +745,8 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
 
     def read_offline_data(self):
         self.set_paper_mode()
-        transaction_count = 0
         file_count = self.count_available_files()
+        rc = file_count > 0
         while file_count > 0:
             count, timestamp = self.get_stroke_data()
             logger.info(f'receiving {count} bytes drawn on UTC {time.strftime("%y%m%d%H%M%S", time.gmtime(timestamp))}')
@@ -764,8 +764,7 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
                     logger.info(f'{file_count} more files on device but I can only download the oldest one')
                 break
             self.delete_oldest_file()
-            transaction_count += 1
-        return transaction_count
+        return rc
 
     def set_name(self, name):
         self.p.execute(Interactions.SET_NAME, name)
@@ -878,7 +877,7 @@ class WacomProtocolSlate(WacomProtocolSpark):
 
             self.get_firmware_version()
             self.select_transfer_gatt()
-            if self.read_offline_data() == 0:
+            if not self.read_offline_data():
                 logger.info('no data to retrieve')
         except WacomEEAGAINException:
             logger.warning('no data, please make sure the LED is blue and the button is pressed to switch it back to green')


### PR DESCRIPTION
To keep the drawings on the device, makes it slightly safer to interact with the device and less annoying when you're doing stroke parsing or similar. All this does is to skip the message to delete the oldest file.

However: because we only ever work on the oldest file, if there are two or more drawings on the device we cannot fetch the others while `--keep-drawings` is provided.

Maybe there's a better option to handle this, I'm all ears.