### PR TITLE
Prompt user to re-register if the authorization fails

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -79,7 +79,7 @@ org.freedesktop.tuhi1.Manager
       successful termination of the search process, either when a device
       has been registered or the timeout expired.
 
-      If the errno is -EAGAIN, the daemon is already searching for devices
+      If the errno is -EBUSY, the daemon is already searching for devices
       on behalf of another client. In this case, this client should wait for
       the Searching property to change and StartSearching() once the
       property is set to False.
@@ -261,7 +261,7 @@ org.freedesktop.tuhi1.Device
       StopListening(). Otherwise, the argument is a negative errno
       indicating the type of error.
 
-      If the errno is -EAGAIN, the daemon is already listening to the device
+      If the errno is -EBUSY, the daemon is already listening to the device
       on behalf of another client. In this case, this client should wait for
       the Listening property to change and StartListening() once the
       property is set to False.
@@ -288,7 +288,7 @@ org.freedesktop.tuhi1.Device
       StopLive(). Otherwise, the argument is a negative errno
       indicating the type of error.
 
-      If the errno is -EAGAIN, the daemon has already enabled live mode on
+      If the errno is -EBUSY, the daemon has already enabled live mode on
       device on behalf of another client. In this case, this client should
       wait for the Live property to change and StartLive() once the property
       is set to False.

--- a/data/ui/MainWindow.ui
+++ b/data/ui/MainWindow.ui
@@ -120,12 +120,85 @@
       </object>
     </child>
     <child>
-      <object class="GtkStack" id="stack_perspectives">
+      <object class="GtkOverlay">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="transition_type">crossfade</property>
         <child>
-          <placeholder/>
+          <object class="GtkStack" id="stack_perspectives">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="transition_type">crossfade</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="index">-1</property>
+          </packing>
+        </child>
+        <child type="overlay">
+          <object class="GtkRevealer" id="overlay_reauth">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="valign">start</property>
+            <property name="transition_type">none</property>
+            <child>
+              <object class="GtkFrame">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">start</property>
+                    <property name="margin_left">12</property>
+                    <property name="margin_right">4</property>
+                    <property name="margin_start">12</property>
+                    <property name="margin_end">4</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_right">10</property>
+                        <property name="label" translatable="yes">Authorization error while connecting to the device </property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="notification_reauth">
+                        <property name="label" translatable="yes">Register</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="no_show_all">True</property>
+                        <property name="margin_right">6</property>
+                        <property name="margin_end">6</property>
+                        <signal name="clicked" handler="_on_reauth_clicked" swapped="no"/>
+                        <style>
+                          <class name="text-button"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+                <style>
+                  <class name="app-notification"/>
+                </style>
+              </object>
+            </child>
+          </object>
         </child>
       </object>
     </child>

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -354,10 +354,10 @@ class TuhiDBusDevice(_TuhiDBus):
         if self.listening:
             logger.debug(f'{self} - already listening')
 
-            # silently ignore it for the current client but send EAGAIN to
+            # silently ignore it for the current client but send EBUSY to
             # other clients
             if sender != self._listening_client[0]:
-                status = GLib.Variant.new_int32(-errno.EAGAIN)
+                status = GLib.Variant.new_int32(-errno.EBUSY)
                 self.signal('ListeningStopped', status, dest=sender)
             return
 
@@ -404,10 +404,10 @@ class TuhiDBusDevice(_TuhiDBus):
         if self.live:
             logger.debug(f'{self} - already in live mode')
 
-            # silently ignore it for the current client but send EAGAIN to
+            # silently ignore it for the current client but send EBUSY to
             # other clients
             if sender != self._listening_client[0]:
-                status = GLib.Variant.new_int32(-errno.EAGAIN)
+                status = GLib.Variant.new_int32(-errno.EBUSY)
                 self.signal('LiveStopped', status, dest=sender)
             return
 
@@ -577,10 +577,10 @@ class TuhiDBusServer(_TuhiDBus):
         if self.is_searching:
             logger.debug('Already searching')
 
-            # silently ignore it for the current client but send EAGAIN to
+            # silently ignore it for the current client but send EBUSY to
             # other clients
             if sender != self._searching_client[0]:
-                status = GLib.Variant.new_int32(-errno.EAGAIN)
+                status = GLib.Variant.new_int32(-errno.EBUSY)
                 self.signal('SearchStopped', status)
             return
 

--- a/tuhi/gui/tuhi.py
+++ b/tuhi/gui/tuhi.py
@@ -156,7 +156,7 @@ class TuhiKeteDevice(_DBusObject):
         'registered':
             (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         'device-error':
-            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT, int)),
+            (GObject.SignalFlags.RUN_FIRST, None, (int,)),
     }
 
     def __init__(self, manager, objpath):
@@ -248,7 +248,7 @@ class TuhiKeteDevice(_DBusObject):
                 logger.error(f'{self}: wrong device, please re-register.')
             elif err < 0:
                 logger.error(f'{self}: an error occured: {os.strerror(-err)}')
-            self.emit('device-error', self, err)
+            self.emit('device-error', err)
             self.notify('listening')
         elif signal == 'SyncState':
             self._sync_state = parameters[0]

--- a/tuhi/gui/tuhi.py
+++ b/tuhi/gui/tuhi.py
@@ -155,6 +155,8 @@ class TuhiKeteDevice(_DBusObject):
             (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
         'registered':
             (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+        'device-error':
+            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT, int)),
     }
 
     def __init__(self, manager, objpath):
@@ -246,6 +248,7 @@ class TuhiKeteDevice(_DBusObject):
                 logger.error(f'{self}: wrong device, please re-register.')
             elif err < 0:
                 logger.error(f'{self}: an error occured: {os.strerror(-err)}')
+            self.emit('device-error', self, err)
             self.notify('listening')
         elif signal == 'SyncState':
             self._sync_state = parameters[0]

--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -344,6 +344,18 @@ class ProtocolError(Exception):
         self.message = message
 
 
+class MissingReplyError(ProtocolError):
+    '''
+    Thrown when we expected a reply but never got one. Usually caused by a
+    timeout.
+    '''
+    def __init__(self, request, message=None):
+        self.request = request
+
+    def __repr__(self):
+        return f'Missing reply for request {self.request}. {self.message}'
+
+
 class AuthorizationError(ProtocolError):
     '''
     The device does not recognize our UUID.
@@ -514,6 +526,8 @@ class Msg(object):
                                     timeout=self.timeout or None,
                                     userdata=self.userdata)
         if self.requires_reply:
+            if self.reply is None:
+                raise MissingReplyError(self.request)
             try:
                 self._handle_reply(self.reply)
                 # no exception? we can assume success

--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -446,6 +446,12 @@ class DeviceError(ProtocolError):
         if self.errorcode == DeviceError.ErrorCode.INVALID_STATE:
             self.errno = errno.EBADE
 
+    def __repr__(self):
+        return f'DeviceError.{self.errorcode.name}'
+
+    def __str__(self):
+        return repr(self)
+
 
 class Msg(object):
     '''

--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -602,7 +602,13 @@ class MsgConnectSpark(Msg):
         if len(self.args) != 6:
             raise ValueError('UUID must be 6 bytes long')
 
-        # uses the default 0xb3 handler
+    def _handle_reply(self, reply):
+        try:
+            super()._handle_reply(reply)
+        except DeviceError as e:
+            if e.errorcode == DeviceError.ErrorCode.GENERAL_ERROR:
+                raise AuthorizationError()
+            raise e
 
 
 class MsgGetName(Msg):

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -23,7 +23,7 @@ from gi.repository import GObject
 from .drawing import Drawing
 from .uhid import UHIDDevice
 import tuhi.protocol
-from tuhi.protocol import NordicData, Interactions, Mode, ProtocolVersion, StrokeFile, UnexpectedDataError, DeviceError, MissingReplyError
+from tuhi.protocol import NordicData, Interactions, Mode, ProtocolVersion, StrokeFile, UnexpectedDataError, DeviceError, MissingReplyError, AuthorizationError
 from .util import list2hex, flatten
 from tuhi.config import TuhiConfig
 
@@ -1016,6 +1016,9 @@ class WacomDevice(GObject.Object):
                 self._wacom_protocol.retrieve_data()
         except DeviceError as e:
             logger.error(f'**** Exception: {e} ****')
+            exception = e
+        except AuthorizationError as e:
+            logger.error(f'Authorization failed, device needs to be re-registered')
             exception = e
         finally:
             self.sync_state = 0

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -18,7 +18,6 @@ import logging
 import threading
 import time
 import uuid
-import errno
 from pathlib import Path
 from gi.repository import GObject
 from .drawing import Drawing
@@ -246,10 +245,6 @@ class DataLogger(object):
             self.logfile.write(f'    source: {source}\n')
 
 
-class WacomException(Exception):
-    errno = errno.ENOSYS
-
-
 class WacomPacket(GObject.Object):
     '''
     A single protocol packet of variable length. The protocol format is a
@@ -421,7 +416,7 @@ class WacomRegisterHelper(WacomProtocolLowLevelComm):
         protocol_version = self.p.execute(Interactions.REGISTER_WAIT_FOR_BUTTON).protocol_version
 
         if protocol_version == ProtocolVersion.ANY:
-            raise WacomException(f'Unknown protocol version: {protocol_version}')
+            raise tuhi.protocol.ProtocolError(f'Unknown protocol version: {protocol_version}')
 
         return protocol_version
 
@@ -1020,7 +1015,7 @@ class WacomDevice(GObject.Object):
                 self.sync_state = 1
                 self._wacom_protocol.retrieve_data()
                 self.sync_state = 0
-        except WacomException as e:
+        except DeviceError as e:
             logger.error(f'**** Exception: {e} ****')
             exception = e
             self.sync_state = 0

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -357,7 +357,7 @@ class WacomProtocolLowLevelComm(GObject.Object):
         length = answer[1]
         args = answer[2:]
         if length > len(args):
-            raise WacomException(f'Invalid answer message length: expected {length}, got {len(args)}')
+            raise UnexpectedDataError(answer, f'Invalid answer message length: expected {length}, got {len(args)}')
         self.nordic_answer = self.nordic_answer[length + 2:]  # opcode + len
         return NordicData(answer[:length + 2])
 

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -395,12 +395,9 @@ class WacomRegisterHelper(WacomProtocolLowLevelComm):
             # expected
             try:
                 self.p.execute(Interactions.CONNECT, uuid)
-            except tuhi.protocol.DeviceError as e:
-                if e.errorcode == tuhi.protocol.DeviceError.ErrorCode.GENERAL_ERROR:
-                    # this is expected
-                    pass
-                else:
-                    raise e
+            except AuthorizationError:
+                # this is expected
+                pass
 
             # The "press button now command" on the spark
             self.p.execute(Interactions.REGISTER_PRESS_BUTTON)

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -1014,12 +1014,11 @@ class WacomDevice(GObject.Object):
                 assert self._wacom_protocol is not None
                 self.sync_state = 1
                 self._wacom_protocol.retrieve_data()
-                self.sync_state = 0
         except DeviceError as e:
             logger.error(f'**** Exception: {e} ****')
             exception = e
-            self.sync_state = 0
         finally:
+            self.sync_state = 0
             self._is_running = False
             self.emit('done', exception)
 


### PR DESCRIPTION
A bit messy because I'm sure half-way through some of the bits get broken because our messages don't all have errnos anymore. But... meh. It'll work in the final product.

The main thing this does after shuffling the exception handling around is to hook up the GUI with the `AuthorizationError`. It shows an overlay with a button to click to re-invoke the setup process.

Easiest way to test: `./builddir/tuhi.devel --config-dir="/tmp/$(date -Idate)" --peek`, register the device, then run the normal `./builddir/tuhi.devel` again.