### PR TITLE
Rename the recovery tool

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -127,6 +127,9 @@ if flake8.found()
         args: ['--ignore=E501,W504',
                join_paths(meson.source_root(), 'tuhi'),
                join_paths(meson.source_root(), 'tuhi', 'gui')])
+   test('flake8-tools', flake8,
+        args: ['--ignore=E501,W504',
+               join_paths(meson.source_root(), 'tools')])
    # the tests need different flake exclusions
    test('flake8-tests', flake8,
         args: ['--ignore=E501,W504,F403,F405',

--- a/tools/raw-log-converter.py
+++ b/tools/raw-log-converter.py
@@ -40,7 +40,7 @@ logging.basicConfig(format='%(asctime)s %(levelname)s: %(name)s: %(message)s',
 logger = logging.getLogger('tuhi')  # set the pseudo-root logger to take advantage of the other loggers
 
 
-def parse_file(filename, tablet_model, orientation):
+def parse_file(filename, file_format, tablet_model, orientation):
     width = tablet_model.width
     height = tablet_model.height
     pressure = tablet_model.pressure
@@ -81,8 +81,10 @@ def parse_file(filename, tablet_model, orientation):
                 stroke.new_abs((p.x * ps, p.y * ps), normalize(p.p))
             stroke.seal()
         d.seal()
-        with open(jsonname, 'w') as fd:
-            fd.write(d.to_json())
+        if file_format == 'json':
+            with open(jsonname, 'w') as fd:
+                fd.write(d.to_json())
+            return
 
         from io import StringIO
         js = json.load(StringIO(d.to_json()))
@@ -106,7 +108,7 @@ def main(args=sys.argv):
     Input data is a raw log file. These are usually stored in
     \t$XDG_DATA_HOME/tuhi/<bluetooth address>/raw/
 
-    Pass the log file to this tool and it will convert it to a JSON file and
+    Pass the log file to this tool and it will convert it to a JSON file or
     an SVG file. Alternatively, use --all to convert all
     all log files containing pen data in the above directory.
 
@@ -137,6 +139,10 @@ def main(args=sys.argv):
                         help='Use defaults from the given tablet model',
                         default='intuos-pro',
                         choices=['intuos-pro', 'slate', 'spark'])
+    parser.add_argument('--format',
+                        help='The format to generate. Default: svg',
+                        default='svg',
+                        choices=['svg', 'json'])
 
     ns = parser.parse_args(args[1:])
     if ns.verbose:
@@ -156,7 +162,7 @@ def main(args=sys.argv):
         'spark': WacomProtocolSpark,
     }
     for f in files:
-        parse_file(f, model_map[ns.tablet_model], ns.orientation)
+        parse_file(f, ns.format, model_map[ns.tablet_model], ns.orientation)
 
 
 if __name__ == '__main__':

--- a/tools/raw-log-converter.py
+++ b/tools/raw-log-converter.py
@@ -97,7 +97,29 @@ def fetch_files():
 
 
 def main(args=sys.argv):
-    parser = argparse.ArgumentParser(description='YAML log to SVG converter')
+    long_description = '''
+    This tool is primarily a debugging tool but can be used to recover
+    "lost" files. Use this tool if Tuhi failed to convert a drawing
+    after downloading it from the device. Obviously after fixing the bug
+    that failed to convert it.
+
+    Input data is a raw log file. These are usually stored in
+    \t$XDG_DATA_HOME/tuhi/<bluetooth address>/raw/
+
+    Pass the log file to this tool and it will convert it to a JSON file and
+    an SVG file. Alternatively, use --all to convert all
+    all log files containing pen data in the above directory.
+
+    Files are placed in $CWD and use file names containing the file time
+    for easier identification.
+
+    Copying the JSON files into the $XDG_DATA_HOME/tuhi/ will make them
+    appear in the GUI.
+    '''.replace('    ', '')
+
+    parser = argparse.ArgumentParser(description='Converter tool from raw Tuhi log files to SVG and Tuhi JSON files.',
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     epilog=long_description)
     parser.add_argument('filename', help='The YAML file to load', nargs='?')
     parser.add_argument('--verbose',
                         help='Show some debugging informations',
@@ -129,9 +151,9 @@ def main(args=sys.argv):
         files = fetch_files()
 
     model_map = {
-            'intuos-pro': WacomProtocolIntuosPro,
-            'slate': WacomProtocolSlate,
-            'spark': WacomProtocolSpark,
+        'intuos-pro': WacomProtocolIntuosPro,
+        'slate': WacomProtocolSlate,
+        'spark': WacomProtocolSpark,
     }
     for f in files:
         parse_file(f, model_map[ns.tablet_model], ns.orientation)


### PR DESCRIPTION
From `test-svg.py` to `raw-log-converter.py`. Makes it look a bit better in the wiki when we start documenting this for #179 