### PR TITLE
protocol: assume the initial stroke point to be 0, 0, 0

### DIFF
--- a/tuhi/protocol.py
+++ b/tuhi/protocol.py
@@ -1348,7 +1348,10 @@ class StrokeFile(object):
         Stroke = namedtuple('Stroke', ['points'])
         Point = namedtuple('Point', ['x', 'y', 'p'])
 
-        last_point = None  # abs coords for most recent point
+        # The Spark can have a delta on the first point in a file. Let's
+        # default to 0, 0, 0 because I don't know what else could be
+        # sensible here.
+        last_point = Point(0, 0, 0)  # abs coords for most recent point
         last_delta = Point(0, 0, 0)  # delta accumulates
 
         strokes = []  # all strokes
@@ -1428,8 +1431,6 @@ class StrokeFile(object):
                 # can process both the same way.
                 if packet_type == StrokeDataType.POINT:
                     packet = StrokePoint(data)
-                    if last_point is None:
-                        last_point = Point(packet.x, packet.y, packet.p)
                 else:
                     packet = StrokeDelta(data)
 


### PR DESCRIPTION
Reproduced on the Spark, first bytes in a new file recording were
- file header: 0x62, 0x38, 0x62, 0x74
- stroke point: 0xbf, 0xff, 0xff, 0x4a, 0x14, 0x29, 0x31, 0x6a
- stroke delta: 0xa8, 0x02, 0x04, 0xc3,

The initial point thus has a delta pressure value 0x6a which must be added to
*something*. And zero is the most sensible *something* that I can think of.

Fixes #111