### PR TITLE
wacom: add a session id field to make it easier to find log files

### DIFF
--- a/DBusInterface.md
+++ b/DBusInterface.md
@@ -336,11 +336,16 @@ files). The JSON objects are "drawing" (the root object), "strokes",
 class Drawing {
         version: uint32
         devicename: string
+        sessionid: string            // used for debugging
         dimensions: [uint32, uint32] // x/y physical dimensions in µm
         timestamp: uint64
         strokes: [ Stroke, Stroke, ...]
 }
 ```
+
+A session id is a random string that identifies a Tuhi session. This is
+debugging information only, it makes it possible to associate a JSON file
+with the corresponding sequence in the log. Do not use in clients.
 
 The **strokes** list contains all strokes of a single drawing, each stroke
 consisting of a number of **points**.
@@ -367,6 +372,7 @@ An expanded file looks like this:
 {
    "version" : 1,                       // JSON file format version number
    "devicename":  "Wacom Bamboo Spark", 
+   "sessionid": "somerandomstring-1",
    "dimensions": [ 100000, 200000],      // width/height in µm
    "timestamp" : 12345,
    "strokes" : [

--- a/tuhi/drawing.py
+++ b/tuhi/drawing.py
@@ -97,6 +97,7 @@ class Drawing(GObject.Object):
         self.timestamp = timestamp  # unix seconds
         self.strokes = []
         self._current_stroke = -1
+        self.session_id = 'unset'
 
     def seal(self):
         # Drop empty strokes
@@ -130,6 +131,7 @@ class Drawing(GObject.Object):
         json_data = {
             'version': self.JSON_FILE_FORMAT_VERSION,
             'devicename': self.name,
+            'sessionid': self.session_id,
             'dimensions': list(self.dimensions),
             'timestamp': self.timestamp,
             'strokes': [s.to_dict() for s in self.strokes]

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -41,6 +41,20 @@ SYSEVENT_NOTIFICATION_SERVICE_UUID = '3a340720-c572-11e5-86c5-0002a5d5c51b'  # N
 SYSEVENT_NOTIFICATION_CHRC_UUID    = '3a340721-c572-11e5-86c5-0002a5d5c51b'  # NOQA
 
 
+class IDGenerator(object):
+    _session = uuid.uuid4().hex
+    _instance = 0
+
+    @classmethod
+    def current(cls):
+        return f'{cls._session}-{cls._instance}'
+
+    @classmethod
+    def next(cls):
+        cls._instance += 1
+        return cls.current()
+
+
 @enum.unique
 class DeviceMode(enum.Enum):
     REGISTER = 1
@@ -199,6 +213,9 @@ class DataLogger(object):
         path = Path(self.logdir, fname)
         self.logfile = open(path, 'w+')
 
+        session_id = IDGenerator.next()
+        self.logger.debug(f'sessionid: {session_id}')
+        self.logfile.write(f'sessionid: {session_id}\n')
         self.logfile.write(f'name: {self.device.name}\n')
         self.logfile.write(f'bluetooth: {self.btaddr}\n')
         self.logfile.write(f'time: {timestamp} # host time: {time.strftime("%Y-%m-%d %H:%M:%S")}\n')
@@ -699,6 +716,7 @@ class WacomProtocolBase(WacomProtocolLowLevelComm):
 
         f = StrokeFile(data)
         drawing = Drawing(self.device.name, (self.width, self.height), timestamp)
+        drawing.session_id = IDGenerator.current()
         ps = self.point_size
 
         def normalize(p):


### PR DESCRIPTION
The session id is a UUID, postfixed by an incrementing number. The UUID stays
the same for Tuhi's livetime, the number increments with every bluetooth
connect/disconnect. Result is e.g. 4e55c30035d043ce9f6f4914fb223820-2.

This session id is printed to the log file, added to the YAML raw logs and to
the JSON file, making it easier which log part resulted in which drawing, etc.