### PR TITLE
Improve the loggers a bit

### DIFF
--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -35,9 +35,6 @@ from tuhi.config import TuhiConfig
 
 DEFAULT_CONFIG_PATH = Path(xdg.BaseDirectory.xdg_data_home, 'tuhi')
 
-logging.basicConfig(format='%(asctime)s %(levelname)s: %(name)s: %(message)s',
-                    level=logging.INFO,
-                    datefmt='%H:%M:%S')
 logger = logging.getLogger('tuhi')
 
 WACOM_COMPANY_IDS = [0x4755, 0x4157]
@@ -426,11 +423,17 @@ class Tuhi(GObject.Object):
 def setup_logging(config_dir):
     session_log_file = Path(config_dir, 'session-logs', f'tuhi-{time.strftime("%y-%m-%d-%H:%M:%S")}.log')
     session_log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    formatter = logging.Formatter(fmt='%(asctime)s %(levelname)s: %(name)s: %(message)s',
+                                      datefmt='%H:%M:%S')
+
     fh = logging.FileHandler(session_log_file)
     fh.setLevel(logging.DEBUG)
+    fh.setFormatter(formatter)
 
     ch = logging.StreamHandler()
-    ch.setLevel(logging.ERROR)
+    ch.setLevel(logging.DEBUG)
+    ch.setFormatter(formatter)
     logger.addHandler(ch)
     logger.addHandler(fh)
     logger.info(f'Session log: {session_log_file}')
@@ -462,6 +465,8 @@ def main(args=sys.argv):
 
     if ns.verbose:
         logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
 
     try:
         mainloop = GLib.MainLoop()

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -163,24 +163,6 @@ class DataLogger(object):
         def recv(self, data):
             return self.parent._recv(self.source, data)
 
-    commands = {
-        0xb1: 'set mode',
-        0xb6: 'set time',
-        0xb7: 'get firmware',
-        0xb9: 'read battery info',
-        0xbb: 'get/set name',
-        0xc1: 'check for data',
-        0xc3: 'start reading',
-        0xc5: 'fetch data',
-        0xc8: 'end of data',
-        0xca: 'ack transaction',
-        0xcc: 'fetch data',
-        0xea: 'get dimensions',
-        0xe5: 'finish registering',
-        0xe6: 'check connection',
-        0xdb: 'get name',
-    }
-
     def __init__(self, bluez_device):
         self.logger = logging.getLogger('tuhi.fw')
         self.device = bluez_device
@@ -240,20 +222,18 @@ class DataLogger(object):
 
         self.logger.debug(f'{self.btaddr}: RX {source} <-- {convert(data)}')
         self._init_file()
-        if data[0] in self.commands:
-            self.logfile.write(f'#         {self.commands[data[0]]}\n')
         self.logfile.write(f'  - recv: {list2hexlist(data)}\n')
         if source != 'NORDIC':
             self.logfile.write(f'    source: {source}\n')
 
     def _request(self, source, request):
-        if request.opcode in self.commands:
-            self.logger.debug(f'command: {self.commands[request.opcode]}')
+        if request.name:
+            self.logger.debug(f'command: {request.name}')
         self.logger.debug(f'{self.btaddr}: TX {source} --> {request.opcode:02x} / {len(request):02x} / {list2hex(request)}')
 
         self._init_file()
-        if request.opcode in self.commands:
-            self.logfile.write(f'#         {self.commands[request.opcode]}\n')
+        if request.name:
+            self.logfile.write(f'#         {request.name}\n')
 
         data = [request.opcode, len(request), *request]
         self.logfile.write(f'  - send: {list2hexlist(data)}\n')


### PR DESCRIPTION
Functional changes:
-  the session log now has the timestamp and the log level (i.e. looks the same as the gui log).
-  we're now using a NordicData object for the raw data logger. We can attach a name to that (e.g.  `Interactions.CONNECT`) and print that. This way we only have one LUT for getting the command names.
- the DataLogger uses a context manager to group request/reply together in the yaml log. Unused atm but this should help writing tools that can replay a whole session.