### PR TITLE
config: don't purge drawings

### DIFF
--- a/tuhi/config.py
+++ b/tuhi/config.py
@@ -69,8 +69,6 @@ class TuhiConfig(GObject.Object):
             config = configparser.ConfigParser()
             config.read(settings)
 
-            self._purge_drawings(directory)
-
             btaddr = directory.name
             assert config['Device']['Address'] == btaddr
             if 'Protocol' not in config['Device']:
@@ -130,19 +128,6 @@ class TuhiConfig(GObject.Object):
 
         configdir = Path(self._base_path, address)
         return [Drawing.from_json(f) for f in configdir.glob('*.json')]
-
-    def _purge_drawings(self, directory):
-        '''Removes all but the most recent 10 files from the config
-        directory. This is primarily done so that no-one relies on the tuhi
-        daemon for permanent storage.'''
-
-        files = [x for x in Path(directory).glob('*.json')]
-
-        if len(files) > 10:
-            files.sort(key=lambda e: e.name)
-            for f in files[:-10]:
-                logger.debug(f'{directory.name}: purging {f.name}')
-                f.unlink()
 
     @classmethod
     def set_base_path(cls, path):


### PR DESCRIPTION
We used to drop all but the last 10 drawings on startup and as the comment
says so that users don't rely on tuhi for storage. That's mostly fine when
Tuhi is a separate daemon but now the primary interface is the GUI. So we can
run into this situation:

- user starts Tuhi (which in turn starts tuhi-gui and tuhi-server)
- tuhi-server downloads 20 fresh drawings from the device
- tuhi-gui crashes before it can fetch them from the tuhi-server
- restart Tuhi, the server now purges 10 out of those 20 drawings that the
  user has never seen. They're gone for good.

Let's drop that code until we figure out a better solution to that (e.g. drop
drawings older than X months but that too is fraught with errors).