### PR TITLE
meson.build: check for missing python modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - run:
           command: |
-            dnf install -y meson gettext python3-devel pygobject3-devel python3-flake8 desktop-file-utils libappstream-glib python3-pytest python3-pyxdg python3-pyyaml
+            dnf install -y meson gettext python3-devel pygobject3-devel python3-flake8 desktop-file-utils libappstream-glib python3-pytest python3-pyxdg python3-pyyaml python3-svgwrite
       - checkout
       - run:
           command: |

--- a/meson.build
+++ b/meson.build
@@ -28,9 +28,26 @@ i18n = import('i18n')
 subdir('po')
 subdir('data')
 
-# Find the directory to install our Python code
 pymod = import('python')
-py3 = pymod.find_installation()
+
+# external python modules that are required for running Tuhi
+python_modules = [
+    'svgwrite',
+    'xdg',
+    'gi',
+    'yaml',
+]
+if meson.version().version_compare('>=0.51')
+    py3 = pymod.find_installation(modules: python_modules)
+else
+    py3 = pymod.find_installation()
+
+    foreach module: python_modules
+        if run_command(py3, '-c', 'import @0@'.format(module)).returncode() != 0
+            error('Failed to find required python module \'@0@\'.'.format(module))
+        endif
+    endforeach
+endif
 python_dir = py3.get_install_dir()
 install_subdir('tuhi',
                install_dir: python_dir,


### PR DESCRIPTION
Check those modules that aren't part of the python installation and bail out
of meson where they're missing. This is technically wrong because we don't
need them at build-time and only at run-time but pragmatically sensible
because we waste too much time dealing with those bugs.

Fixes #200