### PR TITLE
Provide only a single dbus client binding module

### DIFF
--- a/tools/kete.py
+++ b/tools/kete.py
@@ -39,9 +39,6 @@ except ModuleNotFoundError:
     from tuhi.svg import JsonSvg
     import tuhi.dbusclient
 
-    # get those into our namespace for tuhi-live's beneft
-    from tuhi.dbusclient import TUHI_DBUS_NAME, ROOT_PATH, ORG_FREEDESKTOP_TUHI1_MANAGER
-
 
 CONFIG_PATH = Path(xdg.BaseDirectory.xdg_data_home, 'tuhi-kete')
 

--- a/tools/tuhi-live.py
+++ b/tools/tuhi-live.py
@@ -45,8 +45,6 @@ def open_uhid_process(queue_in, conn_out):
 
 
 def maybe_start_tuhi(queue):
-    sys.path
-
     try:
         should_start, verbose = queue.get()
     except KeyboardInterrupt:

--- a/tuhi/dbusclient.py
+++ b/tuhi/dbusclient.py
@@ -149,7 +149,7 @@ class BlueZDevice(_DBusSystemObject):
             self.notify('connected')
 
 
-class TuhiKeteDevice(_DBusObject):
+class TuhiDBusClientDevice(_DBusObject):
     __gsignals__ = {
         'button-press-required':
             (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
@@ -291,7 +291,7 @@ class TuhiKeteDevice(_DBusObject):
         super().terminate()
 
 
-class TuhiKeteManager(_DBusObject):
+class TuhiDBusClientManager(_DBusObject):
     __gsignals__ = {
         'unregistered-device':
             (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
@@ -312,7 +312,7 @@ class TuhiKeteManager(_DBusObject):
     def _init(self, *args, **kwargs):
         logger.info('manager is online')
         for objpath in self.property('Devices'):
-            device = TuhiKeteDevice(self, objpath)
+            device = TuhiDBusClientDevice(self, objpath)
             self._devices[device.address] = device
 
     @GObject.Property
@@ -375,7 +375,7 @@ class TuhiKeteManager(_DBusObject):
                 self.emit('unregistered-device', dev)
                 return
 
-        device = TuhiKeteDevice(self, objpath)
+        device = TuhiDBusClientDevice(self, objpath)
         self._unregistered_devices[objpath] = device
 
         logger.debug(f'New unregistered device: {device}')

--- a/tuhi/dbusclient.py
+++ b/tuhi/dbusclient.py
@@ -152,9 +152,9 @@ class BlueZDevice(_DBusSystemObject):
 class TuhiDBusClientDevice(_DBusObject):
     __gsignals__ = {
         'button-press-required':
-            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
         'registered':
-            (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+            (GObject.SignalFlags.RUN_FIRST, None, ()),
         'device-error':
             (GObject.SignalFlags.RUN_FIRST, None, (int,)),
     }
@@ -239,7 +239,7 @@ class TuhiDBusClientDevice(_DBusObject):
     def _on_signal_received(self, proxy, sender, signal, parameters):
         if signal == 'ButtonPressRequired':
             logger.info(f'{self}: Press button on device now')
-            self.emit('button-press-required', self)
+            self.emit('button-press-required')
         elif signal == 'ListeningStopped':
             err = parameters[0]
             if err == -errno.EACCES:
@@ -280,7 +280,7 @@ class TuhiDBusClientDevice(_DBusObject):
                 self.manager.disconnect(self.s1)
                 del(self.s1)
                 logger.info(f'{self}: Registration successful')
-                self.emit('registered', self)
+                self.emit('registered')
 
     def terminate(self):
         try:

--- a/tuhi/dbusclient.py
+++ b/tuhi/dbusclient.py
@@ -18,7 +18,7 @@ import os
 import logging
 import re
 
-logger = logging.getLogger('tuhi.gui.dbus')
+logger = logging.getLogger('tuhi.dbusclient')
 
 TUHI_DBUS_NAME = 'org.freedesktop.tuhi1'
 ORG_FREEDESKTOP_TUHI1_MANAGER = 'org.freedesktop.tuhi1.Manager'

--- a/tuhi/dbusclient.py
+++ b/tuhi/dbusclient.py
@@ -282,6 +282,23 @@ class TuhiDBusClientDevice(_DBusObject):
                 logger.info(f'{self}: Registration successful')
                 self.emit('registered')
 
+    def start_live(self, fd):
+        fd_list = Gio.UnixFDList.new()
+        fd_list.append(fd)
+
+        res, fds = self.proxy.call_with_unix_fd_list_sync('org.freedesktop.tuhi1.Device.StartLive',
+                                                          GLib.Variant('(h)', (fd,)),
+                                                          Gio.DBusCallFlags.NO_AUTO_START,
+                                                          -1,
+                                                          fd_list,
+                                                          None)
+        if res[0] == 0:
+            self.live = True
+
+    def stop_live(self):
+        self.proxy.StopLive()
+        self.live = False
+
     def terminate(self):
         try:
             self.manager.disconnect(self.s1)

--- a/tuhi/dbusclient.py
+++ b/tuhi/dbusclient.py
@@ -37,7 +37,7 @@ class _DBusObject(GObject.Object):
     _connection = None
 
     def __init__(self, name, interface, objpath):
-        GObject.GObject.__init__(self)
+        super().__init__()
 
         # this is not handled asynchronously because if we fail to
         # get the session bus, we have other issues
@@ -160,9 +160,7 @@ class TuhiKeteDevice(_DBusObject):
     }
 
     def __init__(self, manager, objpath):
-        _DBusObject.__init__(self, TUHI_DBUS_NAME,
-                             ORG_FREEDESKTOP_TUHI1_DEVICE,
-                             objpath)
+        super().__init__(TUHI_DBUS_NAME, ORG_FREEDESKTOP_TUHI1_DEVICE, objpath)
         self.manager = manager
         self.is_registering = False
         self._bluez_device = BlueZDevice(self.property('BlueZDevice'))
@@ -290,7 +288,7 @@ class TuhiKeteDevice(_DBusObject):
         except AttributeError:
             pass
         self._bluez_device.terminate()
-        super(TuhiKeteDevice, self).terminate()
+        super().terminate()
 
 
 class TuhiKeteManager(_DBusObject):
@@ -300,9 +298,7 @@ class TuhiKeteManager(_DBusObject):
     }
 
     def __init__(self):
-        _DBusObject.__init__(self, TUHI_DBUS_NAME,
-                             ORG_FREEDESKTOP_TUHI1_MANAGER,
-                             ROOT_PATH)
+        super().__init__(TUHI_DBUS_NAME, ORG_FREEDESKTOP_TUHI1_MANAGER, ROOT_PATH)
 
         self._devices = {}
         self._unregistered_devices = {}
@@ -350,7 +346,7 @@ class TuhiKeteManager(_DBusObject):
             dev.terminate()
         self._devices = {}
         self._unregistered_devices = {}
-        super(TuhiKeteManager, self).terminate()
+        super().terminate()
 
     def _on_properties_changed(self, proxy, changed_props, invalidated_props):
         if changed_props is None:

--- a/tuhi/gui/window.py
+++ b/tuhi/gui/window.py
@@ -15,8 +15,8 @@ from gettext import gettext as _
 from gi.repository import Gtk, Gio, GLib, GObject
 
 from .drawingperspective import DrawingPerspective
-from .tuhi import TuhiKeteManager
 from .config import Config
+from tuhi.dbusclient import TuhiKeteManager
 
 import logging
 import gi

--- a/tuhi/gui/window.py
+++ b/tuhi/gui/window.py
@@ -100,13 +100,13 @@ class SetupDialog(Gtk.Dialog):
         self._sig = device.connect('button-press-required', self._on_button_press_required)
         device.register()
 
-    def _on_button_press_required(self, tuhi, device):
+    def _on_button_press_required(self, device):
         device.disconnect(self._sig)
 
         self.stack.set_visible_child_name('page2')
         self._sig = device.connect('registered', self._on_registered)
 
-    def _on_registered(self, tuhi, device):
+    def _on_registered(self, device):
         device.disconnect(self._sig)
         self.device = device
         self.response(Gtk.ResponseType.OK)

--- a/tuhi/gui/window.py
+++ b/tuhi/gui/window.py
@@ -101,13 +101,13 @@ class SetupDialog(Gtk.Dialog):
         device.register()
 
     def _on_button_press_required(self, tuhi, device):
-        tuhi.disconnect(self._sig)
+        device.disconnect(self._sig)
 
         self.stack.set_visible_child_name('page2')
         self._sig = device.connect('registered', self._on_registered)
 
     def _on_registered(self, tuhi, device):
-        tuhi.disconnect(self._sig)
+        device.disconnect(self._sig)
         self.device = device
         self.response(Gtk.ResponseType.OK)
 

--- a/tuhi/gui/window.py
+++ b/tuhi/gui/window.py
@@ -16,7 +16,7 @@ from gi.repository import Gtk, Gio, GLib, GObject
 
 from .drawingperspective import DrawingPerspective
 from .config import Config
-from tuhi.dbusclient import TuhiKeteManager
+from tuhi.dbusclient import TuhiDBusClientManager
 
 import logging
 import gi
@@ -132,7 +132,7 @@ class MainWindow(Gtk.ApplicationWindow):
         super().__init__(**kwargs)
 
         self.maximize()
-        self._tuhi = TuhiKeteManager()
+        self._tuhi = TuhiDBusClientManager()
 
         action = Gio.SimpleAction.new_stateful('orientation', GLib.VariantType('s'),
                                                GLib.Variant('s', 'landscape'))


### PR DESCRIPTION
When I started the gui, I just copied `kete.py` for the dbus classes and worked from there. This patchset de-duplicates that bu providing a single module for the dbus objects themselves, used by the gui and kete.