### PR TITLE
Add a flatpak compatibility mode

### DIFF
--- a/tuhi.in
+++ b/tuhi.in
@@ -22,6 +22,9 @@ tuhi_gui = Path('@libexecdir@', 'tuhi-gui')
 @devel@  # NOQA
 
 if __name__ == '__main__':
+    if sys.version_info < (3, 6):
+        sys.exit('Python 3.6 or later required')
+
     args = sys.argv[1:]
     tuhi = subprocess.Popen([tuhi_server] + args)
     try:

--- a/tuhi.in
+++ b/tuhi.in
@@ -14,6 +14,7 @@
 import sys
 import subprocess
 from pathlib import Path
+import argparse
 
 tuhi_server = Path('@libexecdir@', 'tuhi-server')
 tuhi_gui = Path('@libexecdir@', 'tuhi-gui')
@@ -25,10 +26,24 @@ if __name__ == '__main__':
     if sys.version_info < (3, 6):
         sys.exit('Python 3.6 or later required')
 
-    args = sys.argv[1:]
-    tuhi = subprocess.Popen([tuhi_server] + args)
+    parser = argparse.ArgumentParser(description='Tuhi')
+    parser.add_argument('--flatpak-compatibility-mode',
+                        help='Use the flatpak xdg directories',
+                        action='store_true',
+                        default=False)
+    ns, remainder = parser.parse_known_args()
+    if ns.flatpak_compatibility_mode:
+        import os
+
+        basedir = Path.home() / '.var' / 'app' / 'org.freedesktop.Tuhi'
+        print(f'Using flatpak xdg dirs in {basedir}')
+        os.environ['XDG_DATA_HOME'] = os.fspath(basedir / 'data')
+        os.environ['XDG_CONFIG_HOME'] = os.fspath(basedir / 'config')
+        os.environ['XDG_CACHE_HOME'] = os.fspath(basedir / 'cache')
+
+    tuhi = subprocess.Popen([tuhi_server] + remainder)
     try:
-        subprocess.run([tuhi_gui] + args)
+        subprocess.run([tuhi_gui] + remainder)
     except KeyboardInterrupt:
         pass
     tuhi.terminate()

--- a/tuhi/gui/application.py
+++ b/tuhi/gui/application.py
@@ -147,6 +147,9 @@ def gtk_style():
 
 
 def main(argv):
+    if sys.version_info < (3, 6):
+        sys.exit('Python 3.6 or later required')
+
     import gettext
     import locale
     import signal


### PR DESCRIPTION
Add a `--flatpak-compatibility-mode` flag to `tuhi` to start with the `XDG_*` environment adjusted for the flatpak paths. This way it's easier to switch back and forth between the two while testing.