### PR TITLE
meson.build: drop yaml from the required python module list

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,6 @@ python_modules = [
     'svgwrite',
     'xdg',
     'gi',
-    'yaml',
     'cairo',
 ]
 if meson.version().version_compare('>=0.51')


### PR DESCRIPTION
This isn't required for the flatpak, the yaml module is only needed in some of
the debugging/recovery tools but not in Tuhi itself.