### PR TITLE
flatpak: allow access to $HOME

### DIFF
--- a/org.freedesktop.Tuhi.json
+++ b/org.freedesktop.Tuhi.json
@@ -10,7 +10,8 @@
         "--socket=wayland",
         "--talk-name=org.freedesktop.tuhi1",
         "--own-name=org.freedesktop.tuhi1",
-        "--system-talk-name=org.bluez"
+        "--system-talk-name=org.bluez",
+        "--filesystem=home"
     ],
     "modules": [
         {


### PR DESCRIPTION
The whole purpose of Tuhi is to save the files after downloading and the
flatpak sandbox quietly dropped any file we saved in the target directory.

We could use xdg-download or something as allowed directory but let's open up
home itself since we don't want to limit where the files can be saved.

Fixes #230