### PR TITLE
Workaround for Spark register problems

### DIFF
--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -423,6 +423,13 @@ class WacomRegisterHelper(WacomProtocolLowLevelComm):
             except AuthorizationError:
                 # this is expected
                 pass
+            except Exception as e:
+                logger.exception('Got other Exception while registering Spark device')
+                if e.errorcode == DeviceError.ErrorCode.GENERAL_ERROR:
+                    logger.debug('Got GENERAL_ERROR while registering Spark device')
+                    pass
+                else:
+                    raise
 
             # The "press button now command" on the spark
             self.p.execute(Interactions.REGISTER_PRESS_BUTTON)


### PR DESCRIPTION
This is a workaround for #229. I got the same issues described in #229 and noticed while debugging, that the `GENERAL_ERROR` occurs, which should have been raised as an `AuthorizeException`, but it instead reaches the handler as `DeviceError`. I don't know where this originates, but using this workaround worked for me.