### PR TITLE
Add company ID for Augmented Paper

### DIFF
--- a/tuhi/base.py
+++ b/tuhi/base.py
@@ -37,7 +37,7 @@ DEFAULT_CONFIG_PATH = Path(xdg.BaseDirectory.xdg_data_home, 'tuhi')
 
 logger = logging.getLogger('tuhi')
 
-WACOM_COMPANY_IDS = [0x4755, 0x4157]
+WACOM_COMPANY_IDS = [0x4755, 0x4157, 0x424d]
 
 
 class TuhiDevice(GObject.Object):


### PR DESCRIPTION
This adds the company ID for the [Augmented Paper](https://www.montblanc.com/de-de/landingpages/augmented-paper.html) (old version), which is technically a Spark device.