### PR TITLE
gui: pack the flowboxes with pack_end

### DIFF
--- a/tuhi/gui/drawingperspective.py
+++ b/tuhi/gui/drawingperspective.py
@@ -87,7 +87,7 @@ class DrawingPerspective(Gtk.Stack):
         def _hash(drawing):
             return time.strftime('%Y%m', time.gmtime(drawing.timestamp))
 
-        for js in sorted(config.drawings, reverse=True, key=lambda j: j['timestamp']):
+        for js in sorted(config.drawings, key=lambda j: j['timestamp']):
             ts = js['timestamp']
             if ts in self.known_drawings:
                 continue
@@ -102,7 +102,7 @@ class DrawingPerspective(Gtk.Stack):
             except KeyError:
                 fb = Flowbox(time.gmtime(drawing.timestamp))
                 self.flowboxes[key] = fb
-                self.box_all_drawings.add(fb)
+                self.box_all_drawings.pack_end(fb, expand=True, fill=True, padding=0)
             finally:
                 fb.insert(drawing)
 


### PR DESCRIPTION
The first drawings we load are from disk. If we sync a drawing from the device
with a different key (i.e. created in a different month), the new flowbox for
that drawing was appended to the list and in last place. This caused
out-of-order sorting (though a restart of Tuhi would fix it).

So simply change the behavior to sort by oldest timestamp first and pack_end()
for all of them. If we pack all our flowboxes with pack_end, they are
effectively in reverse order, i.e. last one added is first in the list.

Fixes #244