### PR TITLE
gui: add an expanding label to the end, but don't expand flowboxes

### DIFF
--- a/tuhi/gui/drawingperspective.py
+++ b/tuhi/gui/drawingperspective.py
@@ -74,6 +74,11 @@ class DrawingPerspective(Gtk.Stack):
         super().__init__(*args, **kwargs)
         self.known_drawings = {}  # type {timestamp: Drawing()}
         self.flowboxes = {}
+        # Add an expanding emtpy label to the bottom - this pushes all the
+        # real stuff up to the top, forcing a nice alignment
+        l = Gtk.Label("")
+        l.show()
+        self.box_all_drawings.pack_end(l, expand=True, fill=True, padding=100)
         self._zoom = 0
         self._want_listen = True
 
@@ -102,7 +107,7 @@ class DrawingPerspective(Gtk.Stack):
             except KeyError:
                 fb = Flowbox(time.gmtime(drawing.timestamp))
                 self.flowboxes[key] = fb
-                self.box_all_drawings.pack_end(fb, expand=True, fill=True, padding=0)
+                self.box_all_drawings.pack_end(fb, expand=False, fill=True, padding=0)
             finally:
                 fb.insert(drawing)
 


### PR DESCRIPTION
pack_end, introduced in 29761204a92661a8c89189069ba3d95980aece93 means they
align to the bottom of the window. Where there aren't enough drawings to fill
the window, everything is bottom aligned. Hack around this by adding an empty
label to the bottom that expands to the maximum available size and stop
expanding the rest. This new label thus pushes everything up to the top
position.

Fixes 29761204a92661a8c89189069ba3d95980aece93