### PR TITLE
meson.build: explicitly check for gettext to be present

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,8 @@ libexecdir = join_paths(get_option('prefix'), get_option('libexecdir'), 'tuhi')
 
 
 i18n = import('i18n')
+# Workaround for https://github.com/mesonbuild/meson/issues/6165
+find_program('gettext')
 
 subdir('po')
 subdir('data')


### PR DESCRIPTION
There's a meson issue where loading i18n produces a warning about missing
gettext but then proceeds to fail with confusing error messages where the i18n
module is used, see https://github.com/mesonbuild/meson/issues/6165

Work around this by explicitly checking for gettext after loading i18n.

Fixes #270