### PR TITLE
Splitting drawings via GUI

### DIFF
--- a/data/ui/Drawing.ui
+++ b/data/ui/Drawing.ui
@@ -1,56 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="icon_download">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">document-save-as-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-save-as-symbolic</property>
   </object>
   <object class="GtkImage" id="icon_remove">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">edit-delete-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-delete-symbolic</property>
+  </object>
+  <object class="GtkImage" id="icon_split">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-cut-symbolic</property>
   </object>
   <object class="GtkImage" id="image_rotate_left">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">object-rotate-left-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">object-rotate-left-symbolic</property>
   </object>
   <object class="GtkImage" id="image_rotate_right">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">object-rotate-right-symbolic</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">object-rotate-right-symbolic</property>
   </object>
   <template class="Drawing" parent="GtkEventBox">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <signal name="enter-notify-event" handler="_on_enter" swapped="no"/>
     <signal name="leave-notify-event" handler="_on_leave" swapped="no"/>
     <child>
       <object class="GtkBox" id="box_drawing">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_left">20</property>
-        <property name="margin_right">20</property>
+        <property name="can-focus">False</property>
+        <property name="margin-left">20</property>
+        <property name="margin-right">20</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox" id="box_toolbar">
-            <property name="height_request">20</property>
+            <property name="height-request">20</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">center</property>
             <property name="valign">start</property>
-            <property name="margin_left">10</property>
-            <property name="margin_right">10</property>
-            <property name="margin_top">10</property>
-            <property name="margin_bottom">10</property>
+            <property name="margin-left">10</property>
+            <property name="margin-right">10</property>
+            <property name="margin-top">10</property>
+            <property name="margin-bottom">10</property>
             <property name="hexpand">True</property>
             <child>
               <object class="GtkButton" id="btn_rotate_left">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
                 <property name="image">image_rotate_left</property>
                 <signal name="clicked" handler="_on_rotate_button_clicked" swapped="no"/>
               </object>
@@ -63,8 +68,8 @@
             <child>
               <object class="GtkButton" id="btn_rotate_right">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
                 <property name="image">image_rotate_right</property>
                 <signal name="clicked" handler="_on_rotate_button_clicked" swapped="no"/>
               </object>
@@ -77,8 +82,8 @@
             <child>
               <object class="GtkButton" id="btn_download">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
                 <property name="halign">center</property>
                 <property name="image">icon_download</property>
                 <signal name="clicked" handler="_on_download_button_clicked" swapped="no"/>
@@ -90,24 +95,40 @@
               </packing>
             </child>
             <child>
+              <object class="GtkButton" id="btn_split">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">Split the drawing</property>
+                <property name="halign">center</property>
+                <property name="image">icon_split</property>
+                <signal name="clicked" handler="_on_split_button_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+            <child>
               <object class="GtkSeparator">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">10</property>
-                <property name="margin_right">10</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">10</property>
+                <property name="margin-right">10</property>
                 <property name="orientation">vertical</property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">4</property>
+                <property name="position">5</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_remove">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
                 <property name="image">icon_remove</property>
                 <signal name="clicked" handler="_on_delete_button_clicked" swapped="no"/>
               </object>
@@ -127,10 +148,10 @@
         <child>
           <object class="GtkImage" id="image_svg">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
-            <property name="margin_bottom">10</property>
+            <property name="margin-bottom">10</property>
             <property name="stock">gtk-missing-image</property>
             <style>
               <class name="bg-paper"/>

--- a/data/ui/Splitter.ui
+++ b/data/ui/Splitter.ui
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkAdjustment" id="split_adjustment">
+    <property name="lower">1</property>
+    <property name="upper">100</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <template class="Splitter" parent="GtkDialog">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Splitter</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="cancel_button">
+                <property name="label" translatable="yes">Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="_on_cancel" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ok_button">
+                <property name="label" translatable="yes">OK</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="_on_ok" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkScale" id="scale">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="adjustment">split_adjustment</property>
+            <property name="digits">0</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack-type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkDrawingArea" id="drawing_area">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/ui/Splitter.ui
+++ b/data/ui/Splitter.ui
@@ -9,6 +9,8 @@
     <property name="page-increment">10</property>
   </object>
   <template class="Splitter" parent="GtkDialog">
+    <property name="width-request">500</property>
+    <property name="height-request">500</property>
     <property name="can-focus">False</property>
     <property name="title" translatable="yes">Splitter</property>
     <property name="type-hint">dialog</property>

--- a/tuhi/export.py
+++ b/tuhi/export.py
@@ -13,6 +13,7 @@
 
 from gi.repository import GObject
 import svgwrite
+import os
 from svgwrite import mm
 import cairo
 
@@ -83,6 +84,8 @@ class JsonSvg(ImageExportBase):
     _pen_pressure_width_factor = 0.2
 
     def _convert(self):
+        if os.path.isfile(self.filename):
+            return
 
         width, height = self.output_dimensions
         size = width * mm, height * mm

--- a/tuhi/gui/config.py
+++ b/tuhi/gui/config.py
@@ -106,6 +106,31 @@ class Config(GObject.Object):
         self._drawings.append(json.loads(json_string))
         self.notify('drawings')
 
+    def replace_drawing(self, timestamp, json_string):
+        '''Replace the drawing JSON identified by the timestamp in the backend
+        storage. This will update self.drawings.'''
+        self.base_path.mkdir(parents=True, exist_ok=True)
+
+        path = Path(self.base_path, f'{timestamp}.json')
+        if not path.exists():
+            return
+
+        replaced_drawing = list(filter(lambda d: d["timestamp"] == timestamp,
+                                self._drawings))
+
+        if len(replaced_drawing) <= 0:
+            return
+        else:
+            replaced_drawing = replaced_drawing[0]
+
+        with open(path, 'w') as fd:
+            fd.write(json_string)
+
+        self._drawings.remove(replaced_drawing)
+        self._drawings.append(json.loads(json_string))
+        self.notify('drawings')
+
+
     def delete_drawing(self, timestamp):
         # We don't delete json files immediately, we just rename them
         # so we can resurrect them in the future if need be.

--- a/tuhi/gui/drawing.py
+++ b/tuhi/gui/drawing.py
@@ -15,6 +15,7 @@ from gettext import gettext as _
 
 import xdg.BaseDirectory
 import os
+import json
 from pathlib import Path
 from .config import Config
 from .splitter import Splitter
@@ -164,7 +165,37 @@ class Drawing(Gtk.EventBox):
         dialog = Splitter(self)
         response = dialog.run()
 
+        if response == Gtk.ResponseType.OK:
+            self._save_split_drawings(*dialog.split_drawings)
+
         dialog.destroy()
+
+    def _save_split_drawings(self, json1, json2):
+        timestamp1 = json1["timestamp"]
+        timestamp2 = json2["timestamp"]
+
+
+        if timestamp2 in map(lambda d: d["timestamp"], Config().drawings):
+            error_dialog = Gtk.MessageDialog(
+                    transient_for=self,
+                    flags=0,
+                    message_type=Gtk.MessageType.ERROR,
+                    buttons=Gtk.ButtonsType.OK,
+                    text="Error while splitting drawing"
+            )
+            error_dialog.format_secondary_text(
+                    f"A drawing with timestamp {timestamp} already exists. Cannot proceed to save split drawing, otherwise data loss might occur"
+            )
+            error_dialog.run()
+            error_dialog.destroy()
+
+        Config().replace_drawing(timestamp1, json.dumps(json1))
+        Config().add_drawing(timestamp2, json.dumps(json2))
+
+        # Force redraw of this drawing
+        os.remove(self.svg.filename)
+        self.process_svg()
+        self.redraw()
 
     @Gtk.Template.Callback('_on_delete_button_clicked')
     def _on_delete_button_clicked(self, button):

--- a/tuhi/gui/drawing.py
+++ b/tuhi/gui/drawing.py
@@ -161,7 +161,7 @@ class Drawing(Gtk.EventBox):
 
     @Gtk.Template.Callback('_on_split_button_clicked')
     def _on_split_button_clicked(self, button):
-        dialog = Splitter(self.json_data)
+        dialog = Splitter(self)
         response = dialog.run()
 
         dialog.destroy()

--- a/tuhi/gui/drawing.py
+++ b/tuhi/gui/drawing.py
@@ -17,6 +17,7 @@ import xdg.BaseDirectory
 import os
 from pathlib import Path
 from .config import Config
+from .splitter import Splitter
 from tuhi.export import JsonSvg, JsonPng
 
 import gi
@@ -155,6 +156,13 @@ class Drawing(Gtk.EventBox):
                 self.process_svg()
                 shutil.copyfile(self.svg.filename, file)
                 # FIXME: error handling
+
+        dialog.destroy()
+
+    @Gtk.Template.Callback('_on_split_button_clicked')
+    def _on_split_button_clicked(self, button):
+        dialog = Splitter(self.json_data)
+        response = dialog.run()
 
         dialog.destroy()
 

--- a/tuhi/gui/drawing.py
+++ b/tuhi/gui/drawing.py
@@ -172,22 +172,21 @@ class Drawing(Gtk.EventBox):
 
     def _save_split_drawings(self, json1, json2):
         timestamp1 = json1["timestamp"]
-        timestamp2 = json2["timestamp"]
-
+        timestamp2 = json1["timestamp"]
 
         if timestamp2 in map(lambda d: d["timestamp"], Config().drawings):
             error_dialog = Gtk.MessageDialog(
-                    transient_for=self,
                     flags=0,
                     message_type=Gtk.MessageType.ERROR,
                     buttons=Gtk.ButtonsType.OK,
                     text="Error while splitting drawing"
             )
             error_dialog.format_secondary_text(
-                    f"A drawing with timestamp {timestamp} already exists. Cannot proceed to save split drawing, otherwise data loss might occur"
+                    f"A drawing with timestamp {timestamp2} already exists. Cannot proceed to save split drawing, otherwise data loss might occur"
             )
             error_dialog.run()
             error_dialog.destroy()
+            return
 
         Config().replace_drawing(timestamp1, json.dumps(json1))
         Config().add_drawing(timestamp2, json.dumps(json2))

--- a/tuhi/gui/splitter.py
+++ b/tuhi/gui/splitter.py
@@ -59,7 +59,7 @@ class Splitter(Gtk.Dialog):
 
         json_data1["strokes"] = json_data1["strokes"][:self.max_strokes]
         json_data2["strokes"] = json_data2["strokes"][self.max_strokes:]
-        json_data2["timestamp"] += 1
+        json_data2["timestamp"] = json_data1["timestamp"] + self.max_strokes * 1e-5
 
         self.split_drawings = [json_data1, json_data2]
 

--- a/tuhi/gui/splitter.py
+++ b/tuhi/gui/splitter.py
@@ -13,10 +13,9 @@ import os
 import math
 from pathlib import Path
 from .config import Config
-from tuhi.export import JsonPartialSvg
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import GObject, Gtk, GdkPixbuf, Gdk  # NOQA
+from gi.repository import GObject, Gtk
 import cairo
 
 
@@ -46,10 +45,6 @@ class Splitter(Gtk.Dialog):
         self.adjustment.set_value(self.num_strokes)
         self.drawing_area.connect("draw", self._on_draw_image)
 
-
-
-
-
     @Gtk.Template.Callback('_on_cancel')
     def _on_cancel(self, button):
         super().response(Gtk.ResponseType.CANCEL)
@@ -59,6 +54,14 @@ class Splitter(Gtk.Dialog):
     def _on_ok(self, button):
         super().response(Gtk.ResponseType.OK)
         print("OK")
+        json_data1 = self.json_data
+        json_data2 = self.json_data.copy()
+
+        json_data1["strokes"] = json_data1["strokes"][:self.max_strokes]
+        json_data2["strokes"] = json_data2["strokes"][self.max_strokes:]
+        json_data2["timestamp"] += 1
+
+        self.split_drawings = [json_data1, json_data2]
 
     def _on_split_value_changed(self, adjustment):
         self.max_strokes = int(adjustment.get_value())

--- a/tuhi/gui/splitter.py
+++ b/tuhi/gui/splitter.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+
+from gettext import gettext as _
+
+import xdg.BaseDirectory
+import os
+import math
+from pathlib import Path
+from .config import Config
+from tuhi.export import JsonPartialSvg
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import GObject, Gtk, GdkPixbuf, Gdk  # NOQA
+import cairo
+
+
+DATA_PATH = Path(xdg.BaseDirectory.xdg_cache_home, 'tuhi')
+SVG_DATA_PATH = Path(DATA_PATH, 'svg')
+PNG_DATA_PATH = Path(DATA_PATH, 'png')
+
+
+@Gtk.Template(resource_path='/org/freedesktop/Tuhi/ui/Splitter.ui')
+class Splitter(Gtk.Dialog):
+    __gtype_name__ = "Splitter"
+
+    adjustment = Gtk.Template.Child("split_adjustment")
+    ok_button = Gtk.Template.Child("ok_button")
+    cancel_button = Gtk.Template.Child("cancel_button")
+    drawing_area = Gtk.Template.Child("drawing_area")
+
+    def __init__(self, json_data):
+        super().__init__()
+        self.json_data = json_data
+        self.orientation = Config().orientation
+
+        self.num_strokes = len(self.json_data["strokes"])
+        self.max_strokes = self.num_strokes
+        self.adjustment.set_upper(self.num_strokes)
+        self.adjustment.connect("value-changed", self._on_split_value_changed)
+        self.adjustment.set_value(self.num_strokes)
+        self.drawing_area.connect("draw", self._on_draw_image)
+
+
+
+
+
+    @Gtk.Template.Callback('_on_cancel')
+    def _on_cancel(self, button):
+        super().response(Gtk.ResponseType.CANCEL)
+        print("CANCEL")
+
+    @Gtk.Template.Callback('_on_ok')
+    def _on_ok(self, button):
+        super().response(Gtk.ResponseType.OK)
+        print("OK")
+
+    def _on_split_value_changed(self, adjustment):
+        self.max_strokes = int(adjustment.get_value())
+        self.drawing_area.queue_draw()
+        #print("Split value: ", adjustment.get_value(), max_strokes)
+        #self.image_svg.set_from_pixbuf(self.exporter.generate_pixbuf(max_strokes))
+
+    def _on_draw_image(self, widget, cr):
+        print("Drawing")
+        display_width, display_height = float(widget.get_allocated_width()), float(widget.get_allocated_height())
+
+        dimensions = self.json_data["dimensions"]
+
+        drawing_width, drawing_height = -1, -1
+
+        if self.orientation in ['portrait', 'reverse-portrait']:
+            drawing_width = float(dimensions[1])
+            drawing_height = float(dimensions[0])
+        else:
+            drawing_width = float(dimensions[0])
+            drawing_height = float(dimensions[1])
+
+
+        #aspect_ratio = drawing_width / drawing_height
+
+        #margin_x, margin_y = 0.0, 0.0
+
+        #if (display_width / display_height) < aspect_ratio:
+        #    reduced_display_height = display_width / aspect_ratio
+        #    margin_y = display_height - reduced_display_height
+        #    display_height = reduced_display_height
+        #else:
+        #    reduced_display_width = display_height * aspect_ratio
+        #    margin_x = display_width - reduced_display_width
+        #    display_width = reduced_display_width
+
+
+        #print(display_width, display_height)
+
+
+        transform_matrix = cairo.Matrix()
+        if self.orientation == 'reverse-portrait':
+            transform_matrix = cairo.Matrix(xx=0.0,  xy=1.0,
+                                            yx=-1.0, yy=0.0,
+                                            x0=0.0,  y0=1.0)
+        elif self.orientation == 'portrait':
+            transform_matrix = cairo.Matrix(xx=0.0, xy=-1.0,
+                                            yx=1.0, yy=0.0,
+                                            x0=1.0, y0=0.0)
+        elif self.orientation == 'reverse-landscape':
+            transform_matrix = cairo.Matrix(xx=-1.0, xy=0.0,
+                                            yx=0.0,  yy=-1.0,
+                                            x0=1.0,  y0=1.0)
+
+
+        scale_down = cairo.Matrix(xx=1.0/dimensions[0], yy=1.0/dimensions[1])
+
+        scale_up = cairo.Matrix(xx=display_width, yy=display_height)
+
+        cr.identity_matrix()
+        #a = scale_down.multiply(transform_matrix)
+        #cr.transform(a.multiply(scale_up))
+        cr.transform(scale_up)
+        cr.transform(transform_matrix)
+        cr.transform(scale_down)
+
+        print(cr.get_matrix())
+
+
+        for stroke in self.json_data["strokes"][:self.max_strokes]:
+            cr.new_path()
+            cr.set_line_width(drawing_width / display_width * 1.0)
+            cr.set_source_rgb(0.0, 0.0, 0.0)
+
+            first_iteration = True
+            for point in stroke["points"]:
+                x, y = point["position"]
+                display_x = float(x)
+                display_y = float(y)
+
+                if first_iteration:
+                    cr.move_to(display_x, display_y)
+                    first_iteration = False
+                    print(cr.get_matrix().transform_point(display_x, display_y))
+                else:
+                    cr.line_to(display_x, display_y)
+
+            cr.stroke()
+
+

--- a/tuhi/gui/splitter.py
+++ b/tuhi/gui/splitter.py
@@ -34,10 +34,10 @@ class Splitter(Gtk.Dialog):
     cancel_button = Gtk.Template.Child("cancel_button")
     drawing_area = Gtk.Template.Child("drawing_area")
 
-    def __init__(self, json_data):
+    def __init__(self, drawing):
         super().__init__()
-        self.json_data = json_data
-        self.orientation = Config().orientation
+        self.json_data = drawing.json_data
+        self.orientation = drawing.orientation
 
         self.num_strokes = len(self.json_data["strokes"])
         self.max_strokes = self.num_strokes


### PR DESCRIPTION
This is a WIP feature implementation, but I would like to hear your thoughts anyway.

## What this is for
The original Wacom Inkspace app has a "split drawing" feature, it is really useful if you forgot to press that only button the device has and now are left with two drawings overlayed. This PR adds a dialog to Tuhi where the user can select a split position via slider:

<img src="https://user-images.githubusercontent.com/8364768/123121764-b934a880-d445-11eb-8749-f1a8e176f653.png" alt="Screenshot" width=200 />

## Open Questions

### Timestamp as ID

AFAIK, a drawing is uniquely defined through its UNIX timestamp in seconds. In this working implementation, if the user splits a drawing, the part that is split off gets assigned timestamp + 1, since assigning it the current timestamp would mess up the display order. However, if the user decides to split the first part again, a collision occurs. This might not happen very often, but I would suggest changing the Identifier from timestamp to either timestamp + some sort of hash or add precision (e.g. milliseconds) to avoid problems of that kind altogether. Any thoughts?

### Drawing rendering

The PR also contains code to render a drawing from its json_data into a `Gtk.DrawingArea` with cairo. It is more responsive to changes than the current "exported SVG" approach, however I have not benchmarked its performance. Would it make sense to replace the rendering drawings in the DrawingPerspective with it?