### PR TITLE
CI: run apt-get update before apt-get install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Install dependencies
-        run: sudo apt-get install -yq --no-install-suggests --no-install-recommends $UBUNTU_PACKAGES
+        run: |
+          sudo apt-get update -yq
+          sudo apt-get install -yq --no-install-suggests --no-install-recommends $UBUNTU_PACKAGES
       - uses: actions/checkout@v2
       - name: meson
         run: meson builddir


### PR DESCRIPTION
Make sure our packageset is up-to-date

Fixes the CI error in #290 