### PR TITLE
Improved development experience using meson devenv

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -178,6 +178,6 @@ configure_file(input: 'tools/tuhi-gui-flatpak.py',
                copy: true)
 
 tuhi_devenv = environment()
-tuhi_devenv.set('TUHI_DEVEL', meson.current_build_dir())
+tuhi_devenv.set('TUHI_DEVEL_BUILD_DIR', meson.current_build_dir())
 tuhi_devenv.set('PYTHONPATH', meson.current_source_dir())
 meson.add_devenv(tuhi_devenv)

--- a/meson.build
+++ b/meson.build
@@ -176,3 +176,8 @@ endif
 configure_file(input: 'tools/tuhi-gui-flatpak.py',
                output: 'tuhi-gui-flatpak.py',
                copy: true)
+
+tuhi_devenv = environment()
+tuhi_devenv.set('TUHI_DEVEL', meson.current_build_dir())
+tuhi_devenv.set('PYTHONPATH', meson.current_source_dir())
+meson.add_devenv(tuhi_devenv)

--- a/tuhi-gui.in
+++ b/tuhi-gui.in
@@ -17,8 +17,8 @@ from gi.repository import Gio
 
 
 @devel@  # NOQA
-if "TUHI_DEVEL" in os.environ:
-    resource_path = Path(os.environ["TUHI_DEVEL"], 'data', 'tuhi.gresource')
+if "TUHI_DEVEL_BUILD_DIR" in os.environ:
+    resource_path = Path(os.environ["TUHI_DEVEL_BUILD_DIR"], 'data', 'tuhi.gresource')
 else:
     resource_path = Path('@pkgdatadir@', 'tuhi.gresource')
     
@@ -30,9 +30,9 @@ if __name__ == "__main__":
     import gettext
     import locale
 
-    if "TUHI_DEVEL" in os.environ:
-        locale.bindtextdomain('tuhi', Path(os.environ["TUHI_DEVEL"], "po"))
-        gettext.bindtextdomain('tuhi', Path(os.environ["TUHI_DEVEL"], "po"))
+    if "TUHI_DEVEL_BUILD_DIR" in os.environ:
+        locale.bindtextdomain('tuhi', Path(os.environ["TUHI_DEVEL_BUILD_DIR"], "po"))
+        gettext.bindtextdomain('tuhi', Path(os.environ["TUHI_DEVEL_BUILD_DIR"], "po"))
     else:
         locale.bindtextdomain('tuhi', '@localedir@')
         gettext.bindtextdomain('tuhi', '@localedir@')

--- a/tuhi-gui.in
+++ b/tuhi-gui.in
@@ -18,9 +18,11 @@ from gi.repository import Gio
 
 @devel@  # NOQA
 if "TUHI_DEVEL" in os.environ:
-    resource = Gio.resource_load(os.fspath(Path(os.environ["TUHI_DEVEL"], 'data', 'tuhi.gresource')))
+    resource_path = Path(os.environ["TUHI_DEVEL"], 'data', 'tuhi.gresource')
 else:
-    resource = Gio.resource_load(os.fspath(Path('@pkgdatadir@', 'tuhi.gresource')))
+    resource_path = Path('@pkgdatadir@', 'tuhi.gresource')
+    
+resource = Gio.resource_load(os.fspath(resource_path))
 Gio.Resource._register(resource)
 
 

--- a/tuhi-gui.in
+++ b/tuhi-gui.in
@@ -17,7 +17,10 @@ from gi.repository import Gio
 
 
 @devel@  # NOQA
-resource = Gio.resource_load(os.fspath(Path('@pkgdatadir@', 'tuhi.gresource')))
+if "TUHI_DEVEL" in os.environ:
+    resource = Gio.resource_load(os.fspath(Path(os.environ["TUHI_DEVEL"], 'data', 'tuhi.gresource')))
+else:
+    resource = Gio.resource_load(os.fspath(Path('@pkgdatadir@', 'tuhi.gresource')))
 Gio.Resource._register(resource)
 
 
@@ -25,8 +28,12 @@ if __name__ == "__main__":
     import gettext
     import locale
 
-    locale.bindtextdomain('tuhi', '@localedir@')
-    gettext.bindtextdomain('tuhi', '@localedir@')
+    if "TUHI_DEVEL" in os.environ:
+        locale.bindtextdomain('tuhi', Path(os.environ["TUHI_DEVEL"], "po"))
+        gettext.bindtextdomain('tuhi', Path(os.environ["TUHI_DEVEL"], "po"))
+    else:
+        locale.bindtextdomain('tuhi', '@localedir@')
+        gettext.bindtextdomain('tuhi', '@localedir@')
 
     from tuhi.gui.application import main
     main(sys.argv)

--- a/tuhi.in
+++ b/tuhi.in
@@ -11,13 +11,18 @@
 #  GNU General Public License for more details.
 #
 
+import os
 import sys
 import subprocess
 from pathlib import Path
 import argparse
 
-tuhi_server = Path('@libexecdir@', 'tuhi-server')
-tuhi_gui = Path('@libexecdir@', 'tuhi-gui')
+if "TUHI_DEVEL" in os.environ:
+    tuhi_server = Path(os.environ["TUHI_DEVEL"], 'tuhi-server')
+    tuhi_gui = Path(os.environ["TUHI_DEVEL"], 'tuhi-gui')
+else:
+    tuhi_server = Path('@libexecdir@', 'tuhi-server')
+    tuhi_gui = Path('@libexecdir@', 'tuhi-gui')
 
 
 @devel@  # NOQA

--- a/tuhi.in
+++ b/tuhi.in
@@ -17,12 +17,8 @@ import subprocess
 from pathlib import Path
 import argparse
 
-if "TUHI_DEVEL" in os.environ:
-    tuhi_server = Path(os.environ["TUHI_DEVEL"], 'tuhi-server')
-    tuhi_gui = Path(os.environ["TUHI_DEVEL"], 'tuhi-gui')
-else:
-    tuhi_server = Path('@libexecdir@', 'tuhi-server')
-    tuhi_gui = Path('@libexecdir@', 'tuhi-gui')
+tuhi_server = Path(os.environ.get("TUHI_DEVEL", "@libexecdir@"), 'tuhi-server')
+tuhi_gui = Path(os.environ.get("TUHI_DEVEL", "@libexecdir@"), 'tuhi-gui')
 
 
 @devel@  # NOQA

--- a/tuhi.in
+++ b/tuhi.in
@@ -17,8 +17,8 @@ import subprocess
 from pathlib import Path
 import argparse
 
-tuhi_server = Path(os.environ.get("TUHI_DEVEL", "@libexecdir@"), 'tuhi-server')
-tuhi_gui = Path(os.environ.get("TUHI_DEVEL", "@libexecdir@"), 'tuhi-gui')
+tuhi_server = Path(os.environ.get("TUHI_DEVEL_BUILD_DIR", "@libexecdir@"), 'tuhi-server')
+tuhi_gui = Path(os.environ.get("TUHI_DEVEL_BUILD_DIR", "@libexecdir@"), 'tuhi-gui')
 
 
 @devel@  # NOQA


### PR DESCRIPTION
In order to test/debug tuhi, installing it won't be necessary anymore. Instead, you can run tuhi within the meson devenv (invoke `meson devenv -C <builddir>) to develop against it.