### PR TITLE
CI: update some actions to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,13 @@ jobs:
         run: |
           sudo apt-get update -yq
           sudo apt-get install -yq --no-install-suggests --no-install-recommends $UBUNTU_PACKAGES
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: meson
         run: meson builddir
       - name: ninja
         run: ninja -C builddir test
       - name: capture build logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() }}  # even if we fail
         with:
           name: meson logs


### PR DESCRIPTION
Node 12 is deprecated, so let's bump to a newer version

 https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
